### PR TITLE
Publish source code to conjars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+           <execution>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+           </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Changes the pom to include the sources when we publish to conjars since we should be making that public.
