### PR TITLE
SQLLine fails to find JDBC driver if the Java classpath has URL escape c...

### DIFF
--- a/src/main/java/sqlline/ClassNameCompleter.java
+++ b/src/main/java/sqlline/ClassNameCompleter.java
@@ -70,7 +70,7 @@ public class ClassNameCompleter extends StringsCompleter {
 
     Set<String> classes = new HashSet<String>();
     for (URL url : urls) {
-      File file = new File(url.getFile());
+      File file = new File(URLDecoder.decode(url.getFile(), "UTF-8"));
 
       if (file.isDirectory()) {
         Set<String> files = getClassFiles(file.getAbsolutePath(),


### PR DESCRIPTION
...haracters, e.g. space (' ') in it

This could happen if the JARs are in a path with space character in it. This simple patch decodes the URL-encoded file path returned by `url.getFile()` before passing it to `new File(...)`
