### PR TITLE
Fix color output: output style instead of name

### DIFF
--- a/src/main/java/sqlline/ColorBuffer.java
+++ b/src/main/java/sqlline/ColorBuffer.java
@@ -39,6 +39,11 @@ final class ColorBuffer implements Comparable {
     ColorAttr(String style) {
       this.style = style;
     }
+
+    @Override
+    public String toString() {
+      return style;
+    }
   }
 
   private final List<Object> parts = new LinkedList<Object>();


### PR DESCRIPTION
Colored output was not working, it instead printed strings like "BLUE" to the screen.
