### PR TITLE
Add WrappedSQLException to allow IncrementalRows to throw a SQLException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,19 @@
         </executions>
       </plugin>
       <plugin>
+        <!--  To allow JMockit to be loaded first in surefire -->
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.5.1</version>
+        <executions>
+          <execution>
+            <id>getClasspathFilenames</id>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
@@ -132,7 +145,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+          <argLine>-Xmx1024m -XX:MaxPermSize=256m -javaagent:${org.jmockit:jmockit:jar}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,13 @@
       <version>2.10</version>
     </dependency>
     <dependency>
+      <!-- JMockit needs to be on class path before JUnit. -->
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+      <version>1.18</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/src/main/java/sqlline/IncrementalRows.java
+++ b/src/main/java/sqlline/IncrementalRows.java
@@ -70,7 +70,7 @@ class IncrementalRows extends Rows {
           endOfResult = true;
         }
       } catch (SQLException ex) {
-        throw new RuntimeException(ex.toString());
+        throw new WrappedSQLException(ex);
       }
     }
 

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1494,6 +1494,8 @@ public class SqlLine {
 
     if (e instanceof SQLException) {
       handleSQLException((SQLException) e);
+    } else if (e instanceof WrappedSQLException) {
+      handleSQLException((SQLException) e.getCause());
     } else if (!initComplete && !opts.getVerbose()) {
       // all init errors must be verbose
       if (e.getMessage() == null) {

--- a/src/main/java/sqlline/WrappedSQLException.java
+++ b/src/main/java/sqlline/WrappedSQLException.java
@@ -1,0 +1,110 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+
+package sqlline;
+
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+
+/**
+ * Class to wrap a SQLException in a RuntimeException. Classes like
+ * IncrementalRows which are iterable can then throw the
+ * WrappedSqlException which can be handled as a SQLException
+ * would be handled.
+ */
+
+public class WrappedSQLException extends RuntimeException {
+
+  public WrappedSQLException(SQLException ex) {
+    super(ex);
+  }
+
+  public WrappedSQLException() {
+    super();
+  }
+
+  public WrappedSQLException(String message) {
+    super(message);
+  }
+
+  public WrappedSQLException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public WrappedSQLException(Throwable cause) {
+    super(cause);
+  }
+
+  protected WrappedSQLException(String message,
+                                Throwable cause,
+                                boolean enableSuppression,
+                                boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  @Override
+  public String getMessage() {
+    return super.getMessage();
+  }
+
+  @Override
+  public String getLocalizedMessage() {
+    return super.getLocalizedMessage();
+  }
+
+  @Override
+  public synchronized Throwable getCause() {
+    return super.getCause();
+  }
+
+  @Override
+  public synchronized Throwable initCause(Throwable cause) {
+    return super.initCause(cause);
+  }
+
+  @Override
+  public String toString() {
+    return super.toString();
+  }
+
+  @Override
+  public void printStackTrace() {
+    super.printStackTrace();
+  }
+
+  @Override
+  public void printStackTrace(PrintStream s) {
+    super.printStackTrace(s);
+  }
+
+  @Override
+  public void printStackTrace(PrintWriter s) {
+    super.printStackTrace(s);
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return super.fillInStackTrace();
+  }
+
+  @Override
+  public StackTraceElement[] getStackTrace() {
+    return super.getStackTrace();
+  }
+
+  @Override
+  public void setStackTrace(StackTraceElement[] stackTrace) {
+    super.setStackTrace(stackTrace);
+  }
+}

--- a/src/main/java/sqlline/WrappedSQLException.java
+++ b/src/main/java/sqlline/WrappedSQLException.java
@@ -24,33 +24,10 @@ import java.sql.SQLException;
  * would be handled.
  */
 
-public class WrappedSQLException extends RuntimeException {
+class WrappedSQLException extends RuntimeException {
 
   public WrappedSQLException(SQLException ex) {
     super(ex);
-  }
-
-  public WrappedSQLException() {
-    super();
-  }
-
-  public WrappedSQLException(String message) {
-    super(message);
-  }
-
-  public WrappedSQLException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public WrappedSQLException(Throwable cause) {
-    super(cause);
-  }
-
-  protected WrappedSQLException(String message,
-                                Throwable cause,
-                                boolean enableSuppression,
-                                boolean writableStackTrace) {
-    super(message, cause, enableSuppression, writableStackTrace);
   }
 
   @Override

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -28,8 +28,16 @@ import java.util.List;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+
+import org.hsqldb.jdbc.JDBCDatabaseMetaData;
+import org.hsqldb.jdbc.JDBCResultSet;
+
 import org.junit.Ignore;
 import org.junit.Test;
+
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mocked;
 
 import net.hydromatic.scott.data.hsqldb.ScottHsqldb;
 
@@ -56,6 +64,7 @@ public class SqlLineArgsTest {
     beeLine.setOutputStream(beelineOutputStream);
     beeLine.setErrorStream(beelineOutputStream);
     SqlLine.Status status = beeLine.begin(args, null, false);
+
 
     return new Pair(status, os.toString("UTF8"));
   }
@@ -136,15 +145,15 @@ public class SqlLineArgsTest {
   @Test
   public void testNull() throws Throwable {
     checkScriptFile(
-        "values (1, cast(null as integer), cast(null as varchar(3));\n",
-        false,
-        equalTo(SqlLine.Status.OK),
-        containsString(
-            "+-------------+-------------+-----+\n"
-            + "|     C1      |     C2      | C3  |\n"
-            + "+-------------+-------------+-----+\n"
-            + "| 1           | null        |     |\n"
-            + "+-------------+-------------+-----+\n"));
+            "values (1, cast(null as integer), cast(null as varchar(3));\n",
+            false,
+            equalTo(SqlLine.Status.OK),
+            containsString(
+                    "+-------------+-------------+-----+\n"
+                            + "|     C1      |     C2      | C3  |\n"
+                            + "+-------------+-------------+-----+\n"
+                            + "| 1           | null        |     |\n"
+                            + "+-------------+-------------+-----+\n"));
   }
 
   /**
@@ -268,27 +277,48 @@ public class SqlLineArgsTest {
             not(containsString(" 123 ")));
   }
 
-    //"CREATE FUNCTION throwExcept(in INT) RETURNS INT \n" +
-    //"LANGUAGE JAVA DETERMINISTIC NO SQL \n" +
-    //"EXTERNAL NAME 'CLASSPATH:sqlline.SqlLineArgsTest.throwExcept'; \n" +
-  public static int throwExcept(int a) throws SQLException{
-    if ( a == 10 ) {
-      throw new SQLDataException("Obligatory Exception.");
-    }
-    return 0;
-  }
-
   @Test
-  public void testExecutionException() throws Throwable {
-    checkScriptFile( "CREATE TABLE rsTest ( a int);\n" +
-                    "insert into rsTest values (1);\n" +
-                    "insert into rsTest values (0);\n" +
-                    "select 1/a from rsTest;\n" +
-                    "DROP TABLE rsTest;\n" +
-                    "",
-            true,
-            equalTo(SqlLine.Status.OTHER),
-            containsString("Error: data exception: division by zero"));
+  public void testExecutionException(@Mocked final JDBCDatabaseMetaData meta,
+                 @Mocked final JDBCResultSet resultSet)  throws Throwable {
+    new Expectations() {
+      {
+        // prevent calls to functions that also call resultSet.next
+        meta.getDatabaseProductName(); result = "hsqldb";
+        // prevent calls to functions that also call resultSet.next
+        meta.getDatabaseProductVersion(); result = "1.0";
+        // Generate an exception on a call to resultSet.next
+        resultSet.next(); result = new SQLException("Generated Exception.");
+      }
+    };
+    SqlLine sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream sqllineOutputStream = new PrintStream(os);
+    sqlLine.setOutputStream(sqllineOutputStream);
+    sqlLine.setErrorStream(sqllineOutputStream);
+    String[] args = {
+      "-d",
+      "org.hsqldb.jdbcDriver",
+      "-u",
+      "jdbc:hsqldb:res:scott",
+      "-n",
+      "SCOTT",
+      "-p",
+      "TIGER"
+    };
+    DispatchCallback callback = new DispatchCallback();
+    sqlLine.initArgs(args, callback);
+    // If sqlline is not initialized, handleSQLException will print
+    // the entire stack trace.
+    // To prevent that, forcible set init to true.
+    Deencapsulation.setField(sqlLine, "initComplete", true);
+    sqlLine.getConnection();
+    sqlLine.runCommands(Arrays.asList("CREATE TABLE rsTest ( a int);",
+            "insert into rsTest values (1);",
+            "insert into rsTest values (2);",
+            "select a from rsTest; "
+    ), callback);
+    String output = os.toString("UTF8");
+    assertThat(output, containsString("Generated Exception"));
   }
 
     /**

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -18,7 +18,6 @@ import java.io.FileReader;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
-import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -33,10 +33,12 @@ import org.hsqldb.jdbc.JDBCResultSet;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
 
 import net.hydromatic.scott.data.hsqldb.ScottHsqldb;
 
@@ -46,6 +48,7 @@ import static org.junit.Assert.*;
 /**
  * Executes tests of the command-line arguments to SqlLine.
  */
+@RunWith(JMockit.class)
 public class SqlLineArgsTest {
   private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
 
@@ -308,7 +311,7 @@ public class SqlLineArgsTest {
     sqlLine.initArgs(args, callback);
     // If sqlline is not initialized, handleSQLException will print
     // the entire stack trace.
-    // To prevent that, forcible set init to true.
+    // To prevent that, forcibly set init to true.
     Deencapsulation.setField(sqlLine, "initComplete", true);
     sqlLine.getConnection();
     sqlLine.runCommands(Arrays.asList("CREATE TABLE rsTest ( a int);",


### PR DESCRIPTION
JDBC ResultSet can throw a SQLException which gets caught by the IncrementalRows hasNext method. The exception is thrown again as a RuntimeException which causes sqlline to print a stacktrace on the screen. This obscures the error that the database server has sent.
This patch adds a new Exception to wrap SQLException and in SqlLine.java handles the exception like any other SQLException would be handled.