### PR TITLE
'help set' shouldn't break long lines

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1377,7 +1377,7 @@ public class Commands {
       if (cmd.length() == 0
           || commandHandler.getNames().contains(cmd)) {
         String help = commandHandler.getHelpText();
-        if (!help.contains("\n ")) {
+        if (!help.contains("\n")) {
           // Do not wrap if text appears to be pre-formatted (e.g. '!help set')
           help = sqlLine.wrap(help, 60, 20);
         }


### PR DESCRIPTION
Fix the code that detects if a help text is preformatted and prevents breaking long lines. The current code doesn't work for `!help set` (or anything else)