### PR TITLE
Fix loading system properties at startup.

### DIFF
--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -52,8 +52,7 @@ public class SqlLine {
   private final DatabaseConnections connections = new DatabaseConnections();
   public static final String COMMAND_PREFIX = "!";
   private Set<Driver> drivers = null;
-  private final SqlLineOpts opts =
-      new SqlLineOpts(this, System.getProperties());
+  private final SqlLineOpts opts = new SqlLineOpts(this);
   private String lastProgress = null;
   private final Map<SQLWarning, Date> seenWarnings =
       new HashMap<SQLWarning, Date>();
@@ -367,6 +366,7 @@ public class SqlLine {
 
     sqlLineCommandCompleter = new SqlLineCommandCompleter(this);
     reflector = new Reflector(this);
+    opts.loadProperties(System.getProperties());
 
     // attempt to dynamically load signal handler
     try {

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -55,8 +55,12 @@ class SqlLineOpts implements Completer {
       new File(saveDir(), "history").getAbsolutePath();
   private String runFile;
 
-  public SqlLineOpts(SqlLine sqlLine, Properties props) {
+  public SqlLineOpts(SqlLine sqlLine) {
     this.sqlLine = sqlLine;
+  }
+
+  public SqlLineOpts(SqlLine sqlLine, Properties props) {
+    this(sqlLine);
     loadProperties(props);
   }
 

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -102,6 +102,17 @@ public class SqlLineTest extends TestCase {
     assertEquals(1234567, ColorBuffer.centerString("abc", 1234567).length());
   }
 
+  public void testLoadingSystemPropertiesOnCreate(){
+    System.setProperty("sqlline.Isolation", "TRANSACTION_NONE");
+    SqlLine line = new SqlLine();
+    try {
+      assertEquals("TRANSACTION_NONE", line.getOpts().getIsolation());
+    }finally {
+      // set back to the default for tests running in the same JVM.
+      System.setProperty("sqlline.Isolation", "TRANSACTION_REPEATABLE_READ");
+    }
+  }
+
   void assertEquals(String[][] expectedses, String[][] actualses) {
     assertEquals(expectedses.length, actualses.length);
     for (int i = 0; i < expectedses.length; ++i) {

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -102,12 +102,12 @@ public class SqlLineTest extends TestCase {
     assertEquals(1234567, ColorBuffer.centerString("abc", 1234567).length());
   }
 
-  public void testLoadingSystemPropertiesOnCreate(){
+  public void testLoadingSystemPropertiesOnCreate() {
     System.setProperty("sqlline.Isolation", "TRANSACTION_NONE");
     SqlLine line = new SqlLine();
     try {
       assertEquals("TRANSACTION_NONE", line.getOpts().getIsolation());
-    }finally {
+    } finally {
       // set back to the default for tests running in the same JVM.
       System.setProperty("sqlline.Isolation", "TRANSACTION_REPEATABLE_READ");
     }


### PR DESCRIPTION
Previously, if you specified any 'sqlline.' properties as a system property it would cause a NPE because the SqlLine#Reflector was not set yet (it gets set in the SqlLine constructor) because the options are loaded before the constructor.

This adds a test around setting a simple parameter - isolation - and also includes the fix: creating the options at the same place, but lazily loading the system properties.