### PR TITLE
- File output also respects showHeader

### DIFF
--- a/src/main/java/sqlline/SeparatedValuesOutputFormat.java
+++ b/src/main/java/sqlline/SeparatedValuesOutputFormat.java
@@ -29,7 +29,9 @@ class SeparatedValuesOutputFormat implements OutputFormat {
   public int print(Rows rows) {
     int count = 0;
     while (rows.hasNext()) {
-      printRow(rows, rows.next());
+      if (count > 0 || (count == 0 && sqlLine.getOpts().getShowHeader())) {
+        printRow(rows, rows.next());
+      }
       count++;
     }
 


### PR DESCRIPTION
Previously, setting showHeader to false would only work on the table output.  Now it's also supported for CSV's.