### PR TITLE
Adds nickname command for friendly command prompts

### DIFF
--- a/docs/manual.html
+++ b/docs/manual.html
@@ -42,6 +42,8 @@
 					Display all active connections
 					</span></dt></dl></dd><dt><span class="section"><a href="#sect_command_metadata">metadata</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#command_metadata">metadata</a></span><span class="refpurpose"> &#8212;
 					Invoke arbitrary metadata commands
+	                </span></dt></dl></dd><dt><span class="section"><a href="#sect_command_nickname">nickname</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#command_nickname">nickname</a></span><span class="refpurpose"> &#8212;
+					Create a friendly name for the connection (updates command prompt)
 					</span></dt></dl></dd><dt><span class="section"><a href="#sect_command_outputformat">outputformat</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#command_outputformat">outputformat</a></span><span class="refpurpose"> &#8212;
 					Change the method for displaying SQL results
 					</span></dt></dl></dd><dt><span class="section"><a href="#sect_command_primarykeys">primarykeys</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#command_primarykeys">primarykeys</a></span><span class="refpurpose"> &#8212;

--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -1125,6 +1125,7 @@ sqlline> !help
 !isolation        Set the transaction isolation for this connection
 !list             List the current connections
 !metadata         Obtain metadata information
+!nickname         Create a friendly name for the connection (updates command prompt)
 !outputformat     Set the output format for displaying results
                   (table,vertical,csv,tsv,xmlattrs,xmlelements)
 !properties       Connect to the database specified in the properties file(s)
@@ -1464,6 +1465,43 @@ true
 					</screen>
 					</refsect1>
 			</refentry>
+			</section>
+
+			<section id="sect_command_nickname">
+				<title>nickname</title>
+				<refentry id="command_nickname">
+					<refmeta>
+						<refentrytitle>nickname</refentrytitle>
+						<manvolnum>1</manvolnum>
+					</refmeta>
+
+
+					<refnamediv>
+						<refname>nickname</refname>
+						<refpurpose>
+							Create a friendly name for the connection (updates command prompt)
+						</refpurpose>
+					</refnamediv>
+					<refsynopsisdiv>
+						<cmdsynopsis>
+							<command>!nickname</command>
+							<arg choice="req"><replaceable>nickname</replaceable></arg>
+						</cmdsynopsis>
+					</refsynopsisdiv>
+					<refsect1>
+						<title>Description</title>
+						<para>
+							Create a friendly name for the connection (updates command prompt).
+						</para>
+					</refsect1>
+					<refsect1>
+						<title>Example of "nickname" command</title>
+						<screen>
+							0: jdbc:oracle:thin:@localhost:1521:mydb> !nickname devdb
+							0: devdb>
+						</screen>
+					</refsect1>
+				</refentry>
 			</section>
 
 			<section id="sect_command_outputformat">

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -948,6 +948,10 @@ public class Commands {
       connect(props, callback);
       if (callback.isSuccess()) {
         successes++;
+        String nickname = getProperty(props, "nickname", "ConnectionNickname");
+        if (nickname != null) {
+          sqlLine.getDatabaseConnection().setNickname(nickname);
+        }
       }
     }
 
@@ -994,6 +998,32 @@ public class Commands {
     }
 
     connect(props, callback);
+  }
+
+  public void nickname(String line, DispatchCallback callback)
+      throws Exception {
+    String example = "Usage: nickname <nickname for current connection>"
+            + SqlLine.getSeparator();
+
+    String[] parts = sqlLine.split(line);
+    if (parts == null) {
+      callback.setToFailure();
+      sqlLine.error(example);
+      return;
+    }
+
+    String nickname = parts.length < 2 ? null : parts[1];
+    if (nickname != null) {
+      DatabaseConnection current = sqlLine.getDatabaseConnection();
+      if (current != null) {
+        current.setNickname(nickname);
+        callback.setToSuccess();
+      } else {
+        sqlLine.error("nickname command requires active connection");
+      }
+    } else {
+      sqlLine.error(example);
+    }
   }
 
   private String getProperty(Properties props, String... keys) {
@@ -1112,7 +1142,8 @@ public class Commands {
           sqlLine.getColorBuffer()
               .pad(" #" + index++ + "", 5)
               .pad(closed ? sqlLine.loc("closed") : sqlLine.loc("open"), 9)
-              .append(databaseConnection.getUrl()));
+              .pad(databaseConnection.getNickname(), 20)
+              .append(" " + databaseConnection.getUrl()));
     }
 
     callback.setToSuccess();

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -30,6 +30,7 @@ class DatabaseConnection {
   private final String url;
   private final String username;
   private final String password;
+  private String nickname;
   private Schema schema = null;
   private Completer sqlCompleter = null;
 
@@ -248,6 +249,14 @@ class DatabaseConnection {
 
   String getUrl() {
     return url;
+  }
+
+  String getNickname() {
+    return nickname;
+  }
+
+  void setNickname(String nickname) {
+    this.nickname = nickname;
   }
 
   Completer getSqlCompleter() {

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -33,7 +33,6 @@ import jline.console.history.FileHistory;
  *
  * <p>TODO:
  * <ul>
- * <li>User-friendly connection prompts</li>
  * <li>Page results</li>
  * <li>Handle binary data (blob fields)</li>
  * <li>Implement command aliases</li>
@@ -319,6 +318,7 @@ public class SqlLine {
         new ReflectiveCommandHandler(this,
             new StringsCompleter(getConnectionURLExamples()),
             "connect", "open"),
+        new ReflectiveCommandHandler(this, empty, "nickname"),
         new ReflectiveCommandHandler(this, tableCompleter, "describe"),
         new ReflectiveCommandHandler(this, tableCompleter, "indexes"),
         new ReflectiveCommandHandler(this, tableCompleter, "primarykeys"),
@@ -533,6 +533,7 @@ public class SqlLine {
     String user = null;
     String pass = null;
     String url = null;
+    String nickname = null;
 
     for (int i = 0; i < args.length; i++) {
       if (args[i].equals("--help") || args[i].equals("-h")) {
@@ -572,6 +573,8 @@ public class SqlLine {
         commands.add(args[++i]);
       } else if (args[i].equals("-f")) {
         getOpts().setRun(args[++i]);
+      } else if (args[i].equals("-nn")) {
+        nickname = args[++i];
       } else {
         files.add(args[i]);
       }
@@ -586,6 +589,10 @@ public class SqlLine {
               + (driver == null ? "" : driver);
       debug("issuing: " + com);
       dispatch(com, new DispatchCallback());
+    }
+
+    if (nickname != null) {
+      dispatch(COMMAND_PREFIX + "nickname " + nickname, new DispatchCallback());
     }
 
     // now load properties files
@@ -1046,6 +1053,9 @@ public class SqlLine {
     DatabaseConnection dbc = getDatabaseConnection();
     if (dbc == null || dbc.getUrl() == null) {
       return "sqlline> ";
+    } else if (dbc.getNickname() != null) {
+      return getPrompt(connections.getIndex() + ": "
+        + dbc.getNickname()) + "> ";
     } else {
       return getPrompt(connections.getIndex() + ": " + dbc.getUrl()) + "> ";
     }

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -125,6 +125,7 @@ help-tables: List all the tables in the database
 help-columns: List all the columns for the specified table
 help-properties: Connect to the database specified in the properties file(s)
 help-outputformat: Set the output format for displaying results (table,vertical,csv,tsv,xmlattrs,xmlelements)
+help-nickname: Create a friendly name for the connection (updates command prompt)
 
 jline-missing: SQLLine static class check reports the {0} class was not found. Please ensure JLine is on classpath.
 
@@ -202,6 +203,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  -n <username>                   the username to connect as\n \
 \  -p <password>                   the password to connect as\n \
 \  -d <driver class>               the driver class to use\n \
+\  -nn <nickname>                  nickname for the connection\n \
 \  -f <file>                       script file to execute (same as --run)\n \
 \  --color=[true/false]            control whether color is used for display\n \
 \  --showHeader=[true/false]       show column names in query results\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -55,6 +55,8 @@ list
 list — Display all active connections
 metadata
 metadata — Invoke arbitrary metadata commands
+nickname
+nickname - Create a friendly name for the connection (updates command prompt)
 outputformat
 outputformat — Change the method for displaying SQL results
 primarykeys


### PR DESCRIPTION
Adds the nickname command, command line argument, and properties file property to reflect a friendly name in the command prompt and `!list` command. 

```
0: jdbc:oracle:thin:@localhost:1521:mydb> !nickname devdb
0: devdb> !list
 #0  open     devdb              jdbc:oracle:thin:@localhost:1521:mydb
0: devdb>
```

OR invoke at command line: 

```
$ sqlline -u jdbc:oracle:thin:@localhost:1521:mydb -n user -p pass -nn devdb
```

OR use in a properties file:
```
url=jdbc:oracle:thin:@localhost:1521:mydb
user=user
password=pass
nickname=devdb
```

I originally wanted to name this command `alias` and use a `-a` option at the command prompt, but I realized that `alias` and `unalias` also seemed to be reserved for a future command alias function, so I went with `nickname`. I was also a little confused about which documentation files were autogenerated and which I needed to update. Let me know if I missed any! 