### PR TITLE
Adding support for ~ alias for user's home directory

### DIFF
--- a/src/main/java/sqlline/OutputFile.java
+++ b/src/main/java/sqlline/OutputFile.java
@@ -24,6 +24,12 @@ public class OutputFile {
   final PrintWriter out;
 
   public OutputFile(String filename) throws IOException {
+    if (filename.startsWith("~" + File.separator)) {
+      String homedir = System.getProperty("user.home");
+      if (homedir != null) {
+        filename = homedir + filename.substring(1);
+      }
+    }
     file = new File(filename);
     out = new PrintWriter(new FileWriter(file), true);
   }


### PR DESCRIPTION
Here's another one... I think this small change should add support to `!record` and `!run` for expanding `~/` (or `~\` in windows, if that makes sense) into the user's home directory. Not quite as powerful as what `~` does in bash, but I think this probably covers 99% of the cases where people use it. 