### PR TITLE
Fixes for filenames that include spaces

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1231,7 +1231,7 @@ public class Commands {
       return;
     }
 
-    String filename = line.substring("script".length() + 1);
+    String filename = sqlLine.dequote(line.substring("script".length() + 1));
     if (filename == null) {
       callback.setToFailure();
       return;
@@ -1255,12 +1255,11 @@ public class Commands {
    * @param callback Callback for command status
    */
   public void run(String line, DispatchCallback callback) {
-    String filename = line.substring("run".length() + 1);
+    String filename = sqlLine.dequote(line.substring("run".length() + 1));
     if (filename.length() == 0) {
       callback.setToFailure();
       return;
     }
-
     List<String> cmds = new LinkedList<String>();
 
     try {
@@ -1365,7 +1364,7 @@ public class Commands {
       return;
     }
 
-    String filename = line.substring("record".length() + 1);
+    String filename = sqlLine.dequote(line.substring("record".length() + 1));
     if (filename == null) {
       callback.setToFailure();
       return;

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1231,14 +1231,14 @@ public class Commands {
       return;
     }
 
-    String[] parts = sqlLine.split(line, 2, "Usage: script <filename>");
-    if (parts == null) {
+    String filename = line.substring("script".length() + 1);
+    if (filename == null) {
       callback.setToFailure();
       return;
     }
 
     try {
-      outFile = new OutputFile(parts[1]);
+      outFile = new OutputFile(filename);
       sqlLine.setScriptOutputFile(outFile);
       sqlLine.output(sqlLine.loc("script-started", outFile));
       callback.setToSuccess();
@@ -1255,8 +1255,8 @@ public class Commands {
    * @param callback Callback for command status
    */
   public void run(String line, DispatchCallback callback) {
-    String[] parts = sqlLine.split(line, 2, "Usage: run <scriptfile>");
-    if (parts == null) {
+    String filename = line.substring("run".length() + 1);
+    if (filename.length() == 0) {
       callback.setToFailure();
       return;
     }
@@ -1265,7 +1265,7 @@ public class Commands {
 
     try {
       BufferedReader reader =
-          new BufferedReader(new FileReader(parts[1]));
+          new BufferedReader(new FileReader(filename));
       try {
         // ### NOTE: fix for sf.net bug 879427
         StringBuilder cmd = null;
@@ -1365,14 +1365,14 @@ public class Commands {
       return;
     }
 
-    String[] parts = sqlLine.split(line, 2, "Usage: record <filename>");
-    if (parts == null) {
+    String filename = line.substring("record".length() + 1);
+    if (filename == null) {
       callback.setToFailure();
       return;
     }
 
     try {
-      outputFile = new OutputFile(parts[1]);
+      outputFile = new OutputFile(filename);
       sqlLine.setRecordOutputFile(outputFile);
       sqlLine.output(sqlLine.loc("record-started", outputFile));
       callback.setToSuccess();

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -592,7 +592,7 @@ public class SqlLine {
 
     // if a script file was specified, run the file and quit
     if (opts.getRun() != null) {
-      dispatch(COMMAND_PREFIX + "run " + opts.getRun(), callback);
+      dispatch(COMMAND_PREFIX + "run \"" + opts.getRun() + "\"", callback);
       if (callback.isFailure()) {
         status = Status.OTHER;
       }


### PR DESCRIPTION
#71 
Fix Commands that reference a filename so that the portion of input following the command name and space are considered to be the full path to the file. In the current head, this was being split on the space character and therefore would fail on paths that contained spaces.