### PR TITLE
[SQLLINE-38] !run support ~ expansion from home

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1238,7 +1238,7 @@ public class Commands {
     }
 
     try {
-      outFile = new OutputFile(filename);
+      outFile = new OutputFile(expand(filename));
       sqlLine.setScriptOutputFile(outFile);
       sqlLine.output(sqlLine.loc("script-started", outFile));
       callback.setToSuccess();
@@ -1264,7 +1264,7 @@ public class Commands {
 
     try {
       BufferedReader reader =
-          new BufferedReader(new FileReader(filename));
+          new BufferedReader(new FileReader(expand(filename)));
       try {
         // ### NOTE: fix for sf.net bug 879427
         StringBuilder cmd = null;
@@ -1324,6 +1324,21 @@ public class Commands {
     }
   }
 
+  /** Expands "~" to the home directory. */
+  private static String expand(String filename) {
+    if (filename.startsWith("~" + File.separator)) {
+      try {
+        String home = System.getProperty("user.home");
+        if (home != null) {
+          return home + filename.substring(1);
+        }
+      } catch (SecurityException e) {
+        // ignore
+      }
+    }
+    return filename;
+  }
+
   /**
    * Starts or stops saving all output to a file.
    *
@@ -1371,7 +1386,7 @@ public class Commands {
     }
 
     try {
-      outputFile = new OutputFile(filename);
+      outputFile = new OutputFile(expand(filename));
       sqlLine.setRecordOutputFile(outputFile);
       sqlLine.output(sqlLine.loc("record-started", outputFile));
       callback.setToSuccess();

--- a/src/main/java/sqlline/OutputFile.java
+++ b/src/main/java/sqlline/OutputFile.java
@@ -24,24 +24,8 @@ public class OutputFile {
   final PrintWriter out;
 
   public OutputFile(String filename) throws IOException {
-    filename = expand(filename);
     file = new File(filename);
     out = new PrintWriter(new FileWriter(file), true);
-  }
-
-  /** Expands "~" to the home directory. */
-  private static String expand(String filename) {
-    if (filename.startsWith("~" + File.separator)) {
-      try {
-        String home = System.getProperty("user.home");
-        if (home != null) {
-          return home + filename.substring(1);
-        }
-      } catch (SecurityException e) {
-        // ignore
-      }
-    }
-    return filename;
   }
 
   @Override public String toString() {


### PR DESCRIPTION
I faced with an issue that for output (`!record`) it works as it was done by #62 while it does not work for `!run` as it is described in #38 
This PR offers fix for expansion ~ to home directory in the same way like it was done in #62 