### PR TITLE
[SQLLINE-90] Use more relevant exception messages for !metadata, !rec…

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -1408,7 +1408,7 @@ Transaction isolation: TRANSACTION_SERIALIZABLE
           <refsect1>
           <title>Description</title>
           <para>
-          Execute an arbitrary metadata method agains the current
+          Execute an arbitrary metadata method against the current
             connection. refpurpose are separated by spaces.
 
           Use "" for a blank String, and null for a null parameter.

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -158,6 +158,12 @@ public class Commands {
       return;
     }
 
+    if (parts.length == 1) {
+      sqlLine.error("Usage: metadata <methodname> <params...>");
+      callback.setToFailure();
+      return;
+    }
+
     List<Object> params = new LinkedList<Object>(Arrays.asList(parts));
     params.remove(0);
     params.remove(0);
@@ -1231,8 +1237,11 @@ public class Commands {
       return;
     }
 
-    String filename = sqlLine.dequote(line.substring("script".length() + 1));
-    if (filename == null) {
+    String filename;
+    if (line.length() == "script".length()
+        || (filename =
+            sqlLine.dequote(line.substring("script".length() + 1))) == null) {
+      sqlLine.error("Usage: script <file name>");
       callback.setToFailure();
       return;
     }
@@ -1255,8 +1264,11 @@ public class Commands {
    * @param callback Callback for command status
    */
   public void run(String line, DispatchCallback callback) {
-    String filename = sqlLine.dequote(line.substring("run".length() + 1));
-    if (filename.length() == 0) {
+    String filename;
+    if (line.length() == "run".length()
+        || (filename =
+            sqlLine.dequote(line.substring("run".length() + 1))) == null) {
+      sqlLine.error("Usage: run <file name>");
       callback.setToFailure();
       return;
     }
@@ -1379,8 +1391,11 @@ public class Commands {
       return;
     }
 
-    String filename = sqlLine.dequote(line.substring("record".length() + 1));
-    if (filename == null) {
+    String filename;
+    if (line.length() == "record".length()
+        || (filename =
+            sqlLine.dequote(line.substring("record".length() + 1))) == null) {
+      sqlLine.error("Usage: record <file name>");
       callback.setToFailure();
       return;
     }

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -843,6 +843,39 @@ public class SqlLineArgsTest {
             containsString(line1)));
   }
 
+  @Test
+  public void testEmptyMetadata() throws Throwable {
+    final String script = "!metadata\n";
+    final String line = "Usage: metadata <methodname> <params...>";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OTHER),
+        allOf(containsString(line), not(containsString("Exception"))));
+  }
+
+  @Test
+  public void testEmptyRecord() throws Throwable {
+    final String line = "Usage: record <file name>";
+    checkScriptFile(
+        "!record", true, equalTo(SqlLine.Status.OTHER),
+        allOf(containsString(line), not(containsString("Exception"))));
+  }
+
+  @Test
+  public void testEmptyRun() throws Throwable {
+    final String line = "Usage: run <file name>";
+    checkScriptFile(
+        "!run", true, equalTo(SqlLine.Status.OTHER),
+        allOf(containsString(line), not(containsString("Exception"))));
+  }
+
+  @Test
+  public void testEmptyScript() throws Throwable {
+    final String line = "Usage: script <file name>";
+    checkScriptFile(
+        "!script", true, equalTo(SqlLine.Status.OTHER),
+        allOf(containsString(line), not(containsString("Exception"))));
+  }
+
+
   // Work around compile error in JDK 1.6
   private static Matcher<String> allOf(Matcher<String> m1,
       Matcher<String> m2) {


### PR DESCRIPTION
The PR provides
1. More relevant exceptions for empty `!metadata`, `!record`, `!run`, `!script`
2. Tests
3. Misprint fix in docs for `!metadata`

Fixes #90 