### PR TITLE
[SQLLINE-67] Added -log as an external option of !record, close file …

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -892,11 +892,18 @@ public class Commands {
 
   /**
    * Closes the current connection.
+   * Closes the current file writer.
    *
    * @param line Command line
    * @param callback Callback for command status
    */
   public void close(String line, DispatchCallback callback) {
+    // close file writer
+    if (sqlLine.getRecordOutputFile() != null) {
+      // instead of line could be any string
+      stopRecording(line, callback);
+    }
+
     DatabaseConnection databaseConnection = sqlLine.getDatabaseConnection();
     if (databaseConnection == null) {
       callback.setToFailure();

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -510,6 +510,7 @@ public class SqlLine {
     String pass = null;
     String url = null;
     String nickname = null;
+    String logfile = null;
 
     for (int i = 0; i < args.length; i++) {
       if (args[i].equals("--help") || args[i].equals("-h")) {
@@ -537,20 +538,29 @@ public class SqlLine {
         continue;
       }
 
-      if (args[i].equals("-d")) {
-        driver = args[++i];
-      } else if (args[i].equals("-n")) {
-        user = args[++i];
-      } else if (args[i].equals("-p")) {
-        pass = args[++i];
-      } else if (args[i].equals("-u")) {
-        url = args[++i];
-      } else if (args[i].equals("-e")) {
-        commands.add(args[++i]);
-      } else if (args[i].equals("-f")) {
-        getOpts().setRun(args[++i]);
-      } else if (args[i].equals("-nn")) {
-        nickname = args[++i];
+      if (args[i].charAt(0) == '-') {
+        if (i == args.length - 1) {
+          return Status.ARGS;
+        }
+        if (args[i].equals("-d")) {
+          driver = args[++i];
+        } else if (args[i].equals("-n")) {
+          user = args[++i];
+        } else if (args[i].equals("-p")) {
+          pass = args[++i];
+        } else if (args[i].equals("-u")) {
+          url = args[++i];
+        } else if (args[i].equals("-e")) {
+          commands.add(args[++i]);
+        } else if (args[i].equals("-f")) {
+          getOpts().setRun(args[++i]);
+        } else if (args[i].equals("-log")) {
+          logfile = args[++i];
+        } else if (args[i].equals("-nn")) {
+          nickname = args[++i];
+        } else {
+          return Status.ARGS;
+        }
       } else {
         files.add(args[i]);
       }
@@ -569,6 +579,10 @@ public class SqlLine {
 
     if (nickname != null) {
       dispatch(COMMAND_PREFIX + "nickname " + nickname, new DispatchCallback());
+    }
+
+    if (logfile != null) {
+      dispatch(COMMAND_PREFIX + "record " + logfile, new DispatchCallback());
     }
 
     // now load properties files

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -510,7 +510,7 @@ public class SqlLine {
     String pass = null;
     String url = null;
     String nickname = null;
-    String logfile = null;
+    String logFile = null;
 
     for (int i = 0; i < args.length; i++) {
       if (args[i].equals("--help") || args[i].equals("-h")) {
@@ -555,7 +555,7 @@ public class SqlLine {
         } else if (args[i].equals("-f")) {
           getOpts().setRun(args[++i]);
         } else if (args[i].equals("-log")) {
-          logfile = args[++i];
+          logFile = args[++i];
         } else if (args[i].equals("-nn")) {
           nickname = args[++i];
         } else {
@@ -581,8 +581,8 @@ public class SqlLine {
       dispatch(COMMAND_PREFIX + "nickname " + nickname, new DispatchCallback());
     }
 
-    if (logfile != null) {
-      dispatch(COMMAND_PREFIX + "record " + logfile, new DispatchCallback());
+    if (logFile != null) {
+      dispatch(COMMAND_PREFIX + "record " + logFile, new DispatchCallback());
     }
 
     // now load properties files

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -214,6 +214,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  -d <driver class>               the driver class to use\n \
 \  -nn <nickname>                  nickname for the connection\n \
 \  -f <file>                       script file to execute (same as --run)\n \
+\  -log <file>                     file to write output\n \
 \  --color=[true/false]            control whether color is used for display\n \
 \  --csvDelimeter=[delimiter]      Delimiter in csv outputFormat\n \
 \  --csvQuoteCharacter=[char]      Quote character in csv outputFormat\n \

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -226,8 +226,8 @@ public class SqlLineArgsTest {
   @Test
   public void testScriptWithOutput() throws Throwable {
     final String scriptText = "values 100 + 123;\n"
-            + "-- a comment\n"
-            + "values 100 + 253;\n";
+        + "-- a comment\n"
+        + "values 100 + 253;\n";
 
     File scriptFile = File.createTempFile("Script file name", ".sql");
     scriptFile.deleteOnExit();
@@ -240,8 +240,8 @@ public class SqlLineArgsTest {
     outputFile.deleteOnExit();
     runScript(scriptFile, true, outputFile.getAbsolutePath());
     assertFileContains(outputFile,
-            allOf(containsString("| 223                  |"),
-                    containsString("| 353                  |")));
+        allOf(containsString("| 223                  |"),
+            containsString("| 353                  |")));
     final boolean delete = outputFile.delete();
     assertThat(delete, is(true));
   }
@@ -529,9 +529,12 @@ public class SqlLineArgsTest {
   private void assertFileContains(File file, Matcher matcher)
       throws IOException {
     final BufferedReader br = new BufferedReader(new FileReader(file));
-    String line;
     final StringWriter stringWriter = new StringWriter();
-    while ((line = br.readLine()) != null) {
+    for (;;) {
+      final String line = br.readLine();
+      if (line == null) {
+        break;
+      }
       stringWriter.write(line);
       stringWriter.write("\n");
     }


### PR DESCRIPTION
Initially it was intended to have implementation of `-log` option as an external `!record` command. (I guess it is very close to #67)
However while implementation I faced with several issues which fixed also here
So the PR provides the next things:
1. `-log` option as an external `!record` command
2. Close FileWriter in case of SqlLine close. As a side effect of non-closing there were not removed files on Windows while tests. Moreover I found such comment [1] that confirms the issue
3. Close FileReader in `sqlline.SqlLineArgsTest#assertFileContains` which also could lead to non-removed files at least on Windows if this method is used
4. Add validation for case of command line if the last argument is a flag without required argument for that e.g.
`sqlline -d org.hsqldb.jdbcDriver -u`
which in case no fix leads to 
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 4
        at sqlline.SqlLine.initArgs(SqlLine.java:546)
        at sqlline.SqlLine.begin(SqlLine.java:643)
        at sqlline.SqlLine.start(SqlLine.java:373)
        at sqlline.SqlLine.main(SqlLine.java:265)
```

[1] https://github.com/julianhyde/sqlline/blob/f705eea1d666acee4797489649100e7252a00e31/src/test/java/sqlline/SqlLineArgsTest.java#L449