### PR TITLE
[SQLLINE-69] Make bin scripts working after mvn clean install completion

### DIFF
--- a/bin/sqlline
+++ b/bin/sqlline
@@ -2,6 +2,6 @@
 # sqlline - Script to launch SQL shell on Unix, Linux or Mac OS
 
 BINPATH=$(dirname $0)
-exec java -Djava.ext.dirs=$BINPATH sqlline.SqlLine "$@"
+exec java -cp "$BINPATH/../target/*" sqlline.SqlLine "$@"
 
 # End sqlline

--- a/bin/sqlline.bat
+++ b/bin/sqlline.bat
@@ -1,5 +1,5 @@
 @echo off
 :: sqlline.bat - Windows script to launch SQL shell
-java -Djava.ext.dirs=%~dp0 sqlline.SqlLine %*
+java -cp "%~dp0\..\target\*" sqlline.SqlLine %*
 
 :: End sqlline.bat


### PR DESCRIPTION
While attempt to start sqlline faced with issues both on Windows and Linux
The PR provides fix for that (scripts start working after successful `mvn clean install`)
1. On Windows it fails like 
```
-Djava.ext.dirs=D:\work\sqlline\bin\ is not supported.  Use -classpath instead.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
2. On Linux 
` Error: Could not find or load main class sqlline.SqlLine`

I guess the second bullet relates to #69 