### PR TITLE
Make scan output valid, add tests for scan

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -444,28 +444,33 @@ public class Commands {
       names.add(driver.getClass().getName());
     }
 
-    final ColorBuffer colorBuffer = sqlLine.getColorBuffer();
-    sqlLine.output(colorBuffer
-        .bold(colorBuffer.pad(sqlLine.loc("compliant"), 10).getMono())
-        .bold(colorBuffer.pad(sqlLine.loc("jdbc-version"), 8).getMono())
-        .bold(sqlLine.getColorBuffer(sqlLine.loc("driver-class")).getMono()));
+    String compliant =
+        sqlLine.getColorBuffer().pad(sqlLine.loc("compliant"), 10).getMono();
+    String jdbcVersion =
+        sqlLine.getColorBuffer().pad(sqlLine.loc("jdbc-version"), 8).getMono();
+    String driverClass =
+        sqlLine.getColorBuffer(sqlLine.loc("driver-class")).getMono();
+    sqlLine.output(sqlLine.getColorBuffer()
+        .bold(compliant)
+        .bold(jdbcVersion)
+        .bold(driverClass));
 
     for (String name : names) {
       try {
         Driver driver = (Driver) Class.forName(name).newInstance();
         ColorBuffer msg =
-            colorBuffer
-                .pad(driver.jdbcCompliant() ? "yes" : "no", 10)
-                .pad(driver.getMajorVersion() + "."
-                    + driver.getMinorVersion(), 8)
-                .append(name);
+            sqlLine.getColorBuffer()
+            .pad(driver.jdbcCompliant() ? "yes" : "no", 10)
+            .pad(driver.getMajorVersion() + "."
+                + driver.getMinorVersion(), 8)
+            .append(name);
         if (driver.jdbcCompliant()) {
           sqlLine.output(msg);
         } else {
-          sqlLine.output(colorBuffer.red(msg.getMono()));
+          sqlLine.output(sqlLine.getColorBuffer().red(msg.getMono()));
         }
       } catch (Throwable t) {
-        sqlLine.output(colorBuffer.red(name)); // error with driver
+        sqlLine.output(sqlLine.getColorBuffer().red(name)); // error with driver
       }
     }
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -263,6 +263,17 @@ public class SqlLineArgsTest {
                             + "+-------------+-------------+-----+\n"));
   }
 
+  @Test
+  public void testScan() throws Throwable {
+    checkScriptFile(
+        "!scan\n",
+        false,
+        equalTo(SqlLine.Status.OK),
+        containsString(
+            "Compliant Version Driver Class\n"
+            + "yes       2.3     org.hsqldb.jdbcDriver"));
+  }
+
   /**
    * Tests the "close" command,
    * [HIVE-5768] Beeline connection cannot be closed with '!close' command.


### PR DESCRIPTION
Currently the output of `!scan` command is 
```
Compliant Compliant Version Compliant Compliant Version Driver Class
Compliant Compliant Version Compliant Compliant Version Driver Classyes       1.17    org.apache.calcite.avatica.remote.Driver
Compliant Compliant Version Compliant Compliant Version Driver Classyes       1.17    org.apache.calcite.avatica.remote.Driveryes       1.17    org.apache.calcite.jdbc.Driver
Compliant Compliant Version Compliant Compliant Version Driver Classyes       1.17    org.apache.calcite.avatica.remote.Driveryes       1.17    org.apache.calcite.jdbc.Driveryes       1.0     org.apache.commons.dbcp2.PoolingDriver
```
which is a bit messy. The PR addresses to fix it and provides a test for checking