### PR TITLE
Use registered driver if the specified could not be loaded

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1084,10 +1084,24 @@ public class Commands {
       return;
     }
     if (driver == null || driver.length() == 0) {
-      if (!sqlLine.scanForDriver(url)) {
+      if (sqlLine.scanForDriver(url) == null) {
         callback.setToFailure();
         sqlLine.error(sqlLine.loc("no-driver", url));
         return;
+      }
+    } else {
+      try {
+        Class.forName(driver);
+      } catch (ClassNotFoundException cnfe) {
+        String specifiedDriver = driver;
+        if ((driver = sqlLine.scanForDriver(url)) == null) {
+          callback.setToFailure();
+          sqlLine.error(sqlLine.loc("no-specified-driver", specifiedDriver));
+          return;
+        }
+        sqlLine.info(
+            sqlLine.loc(
+                "no-specified-driver-use-existing", specifiedDriver, driver));
       }
     }
 

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1590,31 +1590,32 @@ public class SqlLine {
     }
   }
 
-  boolean scanForDriver(String url) {
+  String scanForDriver(String url) {
     try {
       // already registered
-      if (findRegisteredDriver(url) != null) {
-        return true;
+      Driver driver;
+      if ((driver = findRegisteredDriver(url)) != null) {
+        return driver.getClass().getCanonicalName();
       }
 
       // first try known drivers...
       scanDrivers(true);
 
-      if (findRegisteredDriver(url) != null) {
-        return true;
+      if ((driver = findRegisteredDriver(url)) != null) {
+        return driver.getClass().getCanonicalName();
       }
 
       // now really scan...
       scanDrivers(false);
 
-      if (findRegisteredDriver(url) != null) {
-        return true;
+      if ((driver = findRegisteredDriver(url)) != null) {
+        return driver.getClass().getCanonicalName();
       }
 
-      return false;
+      return null;
     } catch (Exception e) {
       debug(e.toString());
-      return false;
+      return null;
     }
   }
 

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -16,6 +16,8 @@ no-driver: No known driver to handle "{0}"
 setting-prop: Setting property: {0}
 saving-options: Saving preferences to: {0}
 loaded-options: Loaded preferences from: {0}
+no-specified-driver: The specified driver {0} not found.
+no-specified-driver-use-existing: The specified driver {0} not found. The registered driver {1} will be used instead
 
 jdbc-level: JDBC level
 compliant: Compliant

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -867,6 +867,30 @@ public class SqlLineArgsTest {
             containsString(line1)));
   }
 
+  /**
+   * Test case for
+   * <a href="https://github.com/julianhyde/sqlline/issues/107">[SQLLINE-107],
+   * Script fails if the wrong driver is specified with -d option
+   * and there is a valid registered driver for the specified url</a>.
+   */
+  @Test
+  public void testTablesH2WithErrorDriver() throws Throwable {
+    connectionSpec = ConnectionSpec.ERROR_H2_DRIVER;
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!tables\n";
+    final String line0 = "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME |";
+    final String line1 =
+        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        CoreMatchers.allOf(containsString("The specified driver "
+            + connectionSpec.driver
+            + " not found. The registered driver org.h2.Driver will be used instead"),
+            not(containsString("NullPointerException")),
+            containsString(line0),
+            containsString(line1)));
+  }
+
   @Test
   public void testEmptyMetadata() throws Throwable {
     final String script = "!metadata\n";
@@ -924,6 +948,9 @@ public class SqlLineArgsTest {
 
     public static final ConnectionSpec H2 =
         new ConnectionSpec("jdbc:h2:mem:", "sa", "", "org.h2.Driver");
+
+    public static final ConnectionSpec ERROR_H2_DRIVER =
+        new ConnectionSpec("jdbc:h2:mem:", "sa", "", "ERROR_DRIVER");
 
     public static final ConnectionSpec HSQLDB =
         new ConnectionSpec(


### PR DESCRIPTION
The PR fixes #107 by implementation of check if provided driver's class could be loaded or not. 
In case if the specified driver could be loaded it will be used
if it could not be loaded but there is another registered driver for such rule then this registered for the provided url driver will be used however there will be an info message
if it could not be loaded and no other driver is registered for the provided url the exception will be raised