### PR TITLE
 [SQLLINE-111] Make possible to do multiline calls for !all, !sql from file

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -752,39 +752,9 @@ public class Commands {
       callback.setStatus(DispatchCallback.Status.FAILURE);
       return;
     }
-
-    // ### FIXME:  doing the multi-line handling down here means
-    // higher-level logic never sees the extra lines.  So,
-    // for example, if a script is being saved, it won't include
-    // the continuation lines!  This is logged as sf.net
-    // bug 879518.
-
-    // use multiple lines for statements not terminated by ";"
-    try {
-      while (!(line.trim().endsWith(";"))) {
-        StringBuilder prompt = new StringBuilder(sqlLine.getPrompt());
-        for (int i = 0; i < prompt.length() - 1; i++) {
-          if (prompt.charAt(i) != '>') {
-            prompt.setCharAt(i, i % 2 == 0 ? '.' : ' ');
-          }
-        }
-
-        String extra = sqlLine.getConsoleReader().readLine(prompt.toString());
-        if (null == extra) {
-          break; // reader is at the end of data
-        }
-        if (!sqlLine.isComment(extra)) {
-          line += SqlLine.getSeparator() + extra;
-        }
-      }
-    } catch (UserInterruptException uie) {
-      // CTRL-C'd out of the command. Note it, but don't call it an
-      // error.
-      callback.setStatus(DispatchCallback.Status.CANCELED);
-      sqlLine.output(sqlLine.loc("command-canceled"));
+    line = getMultilineInput(line, callback);
+    if (line == null) {
       return;
-    } catch (Exception e) {
-      sqlLine.handleException(e);
     }
 
     if (line.trim().endsWith(";")) {
@@ -874,6 +844,46 @@ public class Commands {
 
     sqlLine.showWarnings();
     callback.setToSuccess();
+  }
+
+  private String getMultilineInput(String line, DispatchCallback callback) {
+    // ### FIXME:  doing the multi-line handling down here means
+    // higher-level logic never sees the extra lines.  So,
+    // for example, if a script is being saved, it won't include
+    // the continuation lines!  This is logged as sf.net
+    // bug 879518.
+
+    // use multiple lines for statements not terminated by ";"
+    try {
+      StringBuilder lineBuilder = new StringBuilder(line);
+      while (!(lineBuilder.toString().trim().endsWith(";"))) {
+        StringBuilder prompt = new StringBuilder(sqlLine.getPrompt());
+        for (int i = 0; i < prompt.length() - 1; i++) {
+          if (prompt.charAt(i) != '>') {
+            prompt.setCharAt(i, i % 2 == 0 ? '.' : ' ');
+          }
+        }
+
+        String extra = sqlLine.getConsoleReader().readLine(prompt.toString());
+        if (null == extra) {
+          break; // reader is at the end of data
+        }
+        if (!sqlLine.isComment(extra)) {
+          lineBuilder.append(SqlLine.getSeparator()).append(extra);
+        }
+      }
+      line = lineBuilder.toString();
+    } catch (UserInterruptException uie) {
+      // CTRL-C'd out of the command. Note it, but don't call it an
+      // error.
+      callback.setStatus(DispatchCallback.Status.CANCELED);
+      sqlLine.output(sqlLine.loc("command-canceled"));
+      return null;
+    } catch (Exception e) {
+      sqlLine.handleException(e);
+    }
+
+    return line;
   }
 
   public void quit(String line, DispatchCallback callback) {
@@ -1184,7 +1194,7 @@ public class Commands {
   public void all(String line, DispatchCallback callback) {
     int index = sqlLine.getDatabaseConnections().getIndex();
     boolean success = true;
-
+    line = getMultilineInput(line, callback);
     for (int i = 0; i < sqlLine.getDatabaseConnections().size(); i++) {
       sqlLine.getDatabaseConnections().setIndex(i);
       sqlLine.output(

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -827,7 +827,9 @@ public class SqlLine {
       return false;
     }
 
-    if (line.startsWith(COMMAND_PREFIX)) {
+    if (line.startsWith(COMMAND_PREFIX)
+        && !line.regionMatches(1, "sql", 0, "sql".length())
+        && !line.regionMatches(1, "all", 0, "all".length())) {
       return false;
     }
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -970,6 +970,42 @@ public class SqlLineArgsTest {
         allOf(containsString(line), not(containsString("Exception"))));
   }
 
+  @Test
+  public void testSqlMultiline() throws Throwable {
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!sql \n"
+        + "values \n"
+        + "(1, 2) \n"
+        + ";\n";
+    final String line1 = "+-------------+-------------+\n"
+        + "|     C1      |     C2      |\n"
+        + "+-------------+-------------+\n"
+        + "| 1           | 2           |\n"
+        + "+-------------+-------------+";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        containsString(line1)
+    );
+  }
+
+  @Test
+  public void testAllMultiline() throws Throwable {
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!all \n"
+        + "values \n"
+        + "(1, '2') \n"
+        + ";\n";
+    final String line1 = "+-------------+----+\n"
+        + "|     C1      | C2 |\n"
+        + "+-------------+----+\n"
+        + "| 1           | 2  |\n"
+        + "+-------------+----+";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        containsString(line1)
+    );
+  }
+
   // Work around compile error in JDK 1.6
   private static Matcher<String> allOf(Matcher<String> m1,
       Matcher<String> m2) {


### PR DESCRIPTION
The PR provides the next things
1. Allow to continue command on next lines if the first line contains only `!all`instead of failing with StringIndexOutOfBoundsException. So it fixes #111 
2. Make possible to do multiline calls for `!all` and `!sql` at least to allow writing tests for such multiline calls
 