### PR TITLE
[SQLLINE-55] Fix NPE when invalid URL is provided

### DIFF
--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -129,6 +129,7 @@ class DatabaseConnection {
     if (!foundDriver) {
       sqlLine.output(sqlLine.loc("autoloading-known-drivers", url));
       sqlLine.registerKnownDrivers();
+      theDriver = DriverManager.getDriver(url);
     }
 
     try {

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -952,6 +952,16 @@ public class SqlLineArgsTest {
   }
 
   @Test
+  public void testH2TablesWithErrorUrl() throws Throwable {
+    connectionSpec = ConnectionSpec.ERROR_H2_URL;
+    final String script = "!tables\n";
+
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OTHER),
+        CoreMatchers.allOf(containsString("No suitable driver"),
+            not(containsString("NullPointerException"))));
+  }
+
+  @Test
   public void testEmptyMetadata() throws Throwable {
     final String script = "!metadata\n";
     final String line = "Usage: metadata <methodname> <params...>";
@@ -1007,6 +1017,9 @@ public class SqlLineArgsTest {
 
     public static final ConnectionSpec ERROR_H2_DRIVER =
         new ConnectionSpec("jdbc:h2:mem:", "sa", "", "ERROR_DRIVER");
+
+    public static final ConnectionSpec ERROR_H2_URL =
+        new ConnectionSpec("ERROR_URL", "sa", "", "org.h2.Driver");
 
     public static final ConnectionSpec HSQLDB =
         new ConnectionSpec(


### PR DESCRIPTION
When no driver is found, `theDriver` variable is still null, then we attempt to load existing drivers but do not attempt to set the `theDriver` variable one more time, thus NPE occurs when we call driver connect method (https://github.com/julianhyde/sqlline/blob/77dc3f6bfd0939a912d6dbe949967457d028d43a/src/main/java/sqlline/DatabaseConnection.java#L157).

Example of output after the fix:
```
No known driver to handle "XXX". Searching for known drivers...
Error: No suitable driver (state=08001,code=0)
java.sql.SQLException: No suitable driver
	at java.sql.DriverManager.getDriver(DriverManager.java:315)
	at sqlline.DatabaseConnection.connect(DatabaseConnection.java:132)
	at sqlline.DatabaseConnection.getConnection(DatabaseConnection.java:205)
	at sqlline.Commands.connect(Commands.java:1126)
	at sqlline.Commands.connect(Commands.java:1018)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sqlline.ReflectiveCommandHandler.execute(ReflectiveCommandHandler.java:38)
	at sqlline.SqlLine.dispatch(SqlLine.java:806)
	at sqlline.SqlLine.initArgs(SqlLine.java:577)
	at sqlline.SqlLine.begin(SqlLine.java:658)
	at sqlline.SqlLine.start(SqlLine.java:374)
	at sqlline.SqlLine.main(SqlLine.java:266)
sqlline version 1.5.0-SNAPSHOT
```