### PR TITLE
[SQLLINE-120] Do not keep connection if it fails to do connection stuff

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1120,14 +1120,16 @@ public class Commands {
           .readLine("Enter password for " + url + ": ", '*');
     }
 
+    DatabaseConnection connection =
+        new DatabaseConnection(sqlLine, driver, url, username, password);
     try {
-      sqlLine.getDatabaseConnections().setConnection(
-          new DatabaseConnection(sqlLine, driver, url, username, password));
+      sqlLine.getDatabaseConnections().setConnection(connection);
       sqlLine.getDatabaseConnection().getConnection();
-
       sqlLine.setCompletions();
       callback.setToSuccess();
     } catch (Exception e) {
+      connection.close();
+      sqlLine.getDatabaseConnections().removeConnection(connection);
       callback.setToFailure();
       sqlLine.error(e);
     }

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -35,7 +35,7 @@ class DatabaseConnection {
   private Completer sqlCompleter = null;
 
   public DatabaseConnection(SqlLine sqlLine, String driver, String url,
-      String username, String password) throws SQLException {
+      String username, String password) {
     this.sqlLine = sqlLine;
     this.driver = driver;
     this.url = url;

--- a/src/main/java/sqlline/DatabaseConnections.java
+++ b/src/main/java/sqlline/DatabaseConnections.java
@@ -49,6 +49,13 @@ class DatabaseConnections implements Iterable<DatabaseConnection> {
     }
   }
 
+  public void removeConnection(DatabaseConnection connection) {
+    if (connections.indexOf(connection) != -1) {
+      connections.remove(connection);
+      index--;
+    }
+  }
+
   public void setConnection(DatabaseConnection connection) {
     if (connections.indexOf(connection) == -1) {
       connections.add(connection);


### PR DESCRIPTION
If connection fails while initialization (e.g. file not found in case calcite csv adapter or password not hashed in H2 and etc) then it still in memory and will fail again while closing because of reconnection attempt.
This PR offers to close such non-working connections immediately
Looks like it could help with  #117 as well