### PR TITLE
[SQLLINE-121] Make SqlLine#split stable for one symbol commands

### DIFF
--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1426,8 +1426,9 @@ public class SqlLine {
         tokenStart = i;
       }
     }
-    if (lastProcessedIndex != line.length() - 1
-        && (limit == 0 || limit > tokens.size())) {
+    if ((lastProcessedIndex != line.length() - 1
+            && (limit == 0 || limit > tokens.size()))
+        || (lastProcessedIndex == 0 && line.length() == 1)) {
       tokens.add(line.substring(tokenStart, line.length()));
     }
     String[] ret = new String[tokens.size()];

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -374,6 +374,23 @@ public class SqlLineArgsTest {
 
   /**
    * Test case for
+   * <a href="https://github.com/julianhyde/sqlline/issues/121">!?, !#
+   * and other one-symbol length commands stopped working</a>
+   *
+   * '!?' should work in the same way as '!help'.
+   */
+  @Test
+  public void testHelpAsQuestionMark() throws Throwable {
+    final String script = "!?\n";
+    checkScriptFile(script, false,
+        equalTo(SqlLine.Status.OK),
+        allOf(not(containsString("Unknown command: ?")),
+            containsString(
+                 "!autocommit         Set autocommit mode on or off")));
+  }
+
+  /**
+   * Test case for
    * <a href="https://github.com/julianhyde/sqlline/issues/49">[SQLLINE-49]
    * !manual command fails</a>.
    */

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -145,6 +145,12 @@ public class SqlLineTest extends TestCase {
     assertEquals(
         new String[]{"set", "timestampformat", "01/01/1970T12:32:12"}, strings);
 
+    strings = line.split("?", " ");
+    assertEquals(new String[]{"?"}, strings);
+
+    strings = line.split("#", " ");
+    assertEquals(new String[]{"#"}, strings);
+
     try {
       line.split("set csvdelimiter '", " ");
       fail("Non-paired quote is not allowed");


### PR DESCRIPTION
The PR provides corrections for one symbol commands like `!?`, `!#` and fixes #121 

