### PR TITLE
[SQLLINE-123] Make SqlLineArgsTest#testScan stable in case of several registered drivers

### DIFF
--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -237,7 +237,6 @@ public class SqlLineArgsTest {
     os.close();
 
     File outputFile = new File("testScriptWithOutput.out");
-    System.out.println("outputFile " + outputFile.getAbsoluteFile());
     outputFile.deleteOnExit();
     runScript(scriptFile, true, outputFile.getAbsolutePath());
     assertFileContains(outputFile,
@@ -266,11 +265,11 @@ public class SqlLineArgsTest {
 
   @Test
   public void testScan() throws Throwable {
-    final String expected = "Compliant Version Driver Class\n"
-        + "yes       2.3     org.hsqldb.jdbcDriver";
+    final String line0 = "Compliant Version Driver Class\n";
+    final String line1 = "yes       2.3     org.hsqldb.jdbcDriver";
     checkScriptFile("!scan\n", false,
         equalTo(SqlLine.Status.OK),
-        containsString(expected));
+        allOf(containsString(line0), containsString(line1)));
   }
 
   /**


### PR DESCRIPTION
The PR makes testScan working in case of several registered drivers and fixes #123 
1. Split expected output into header and a driver description's line
2. Remove extra `System.out.println`