### PR TITLE
[SQLLINE-52] Set isolation level if supported otherwise use default

### DIFF
--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -34,6 +34,8 @@ class SqlLineOpts implements Completer {
       TerminalFactory.get().getWidth();
   private static final int DEFAULT_MAX_HEIGHT =
       TerminalFactory.get().getHeight();
+  public static final String DEFAULT_TRANSACTION_ISOLATION =
+      "TRANSACTION_REPEATABLE_READ";
   private SqlLine sqlLine;
   private boolean autoSave = false;
   private boolean silent = false;
@@ -60,7 +62,7 @@ class SqlLineOpts implements Completer {
   private int maxColumnWidth = 15;
   int rowLimit = 0;
   int timeout = -1;
-  private String isolation = "TRANSACTION_REPEATABLE_READ";
+  private String isolation = DEFAULT_TRANSACTION_ISOLATION;
   private String outputFormat = "table";
   private boolean trimScripts = true;
   private File rcFile = new File(saveDir(), "sqlline.properties");
@@ -377,7 +379,11 @@ class SqlLineOpts implements Completer {
   }
 
   public void setIsolation(String isolation) {
-    this.isolation = isolation;
+    if (DEFAULT.equalsIgnoreCase(isolation)) {
+      this.isolation = DEFAULT_TRANSACTION_ISOLATION;
+    } else {
+      this.isolation = isolation.toUpperCase(Locale.ROOT);
+    }
   }
 
   public String getIsolation() {

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -161,6 +161,7 @@ connected: Connected to: {0} (version {1})
 driver: Driver: {0} (version {1})
 autocommit-status: Autocommit status: {0}
 isolation-status: Transaction isolation: {0}
+isolation-level-not-supported: Transaction isolation level {0} is not supported. Default ({1}) will be used instead.
 unknown-format: Unknown output format "{0}". Possible values: {1}
 
 closed: closed

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -1134,6 +1134,7 @@ Synopsis
 Description
 
 Set the isolation level for the current transaction. For a description of the different isolation levels, see http://java.sun.com/j2se/1.3/docs/api/java/sql/Connection.html#field_detail.
+If the specified isolation level is not supported or DEFAULT is specified then there will be used level returned by java.sql.DatabaseMetaData#getDefaultTransactionIsolation
 
 Example of "isolation" command
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -731,6 +731,24 @@ public class SqlLineArgsTest {
     }
   }
 
+  @Test
+  public void testIsolationSetting() throws Throwable {
+    final String script0 = "!isolation TRANSACTION_NONE\n";
+    checkScriptFile(script0, true, equalTo(SqlLine.Status.OTHER),
+        containsString("Transaction isolation level TRANSACTION_NONE "
+            + "is not supported. Default (TRANSACTION_READ_COMMITTED) "
+            + "will be used instead."));
+  }
+
+  @Test
+  public void testDefaultIsolation() throws Throwable {
+    final String script1 = "!isolation default\n";
+    checkScriptFile(script1, true, equalTo(SqlLine.Status.OK),
+        allOf(
+            not(containsString("Transaction isolation level")),
+            not(containsString("is not supported"))));
+  }
+
   /**
    * HIVE-4566, "NullPointerException if typeinfo and nativesql commands are
    * executed at beeline before a DB connection is established".


### PR DESCRIPTION
The PR provides
1. Default isolation level support
2. Make isolation case insensitive

also it fixes #52 