### PR TITLE
Update !help description with actual output

### DIFF
--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -94,8 +94,8 @@ help-set: Set a sqlline variable\
 \n                           NULL values\
 \nnumberFormat    pattern    Format numbers using\
 \n                           DecimalFormat pattern\
-\noutputFormat    table/vertical/csv/tsv Format mode for\
-\n                           result display\
+\noutputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json\
+\n                           Format mode for result display\
 \npropertiesFile  path       File from which SqlLine reads\
 \n                           properties on startup; default is\
 \n                           $HOME/.sqlline/sqlline.properties\

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -1026,46 +1026,124 @@ Example of "help" command
 
 sqlline> !help
 
-!all              Execute the specified SQL against all the current connections
-!autocommit       Set autocommit mode on or off
-!batch            Start or execute a batch of statements
-!brief            Set verbose mode off
-!close            Close the current connection to the database
-!columns          List all the columns for the specified table
-!commit           Commit the current transaction (if autocommit is off)
-!connect          Open a new connection to the database.
-!dbinfo           Give metadata information about the database
-!describe         Describe a table
-!dropall          Drop all tables in the current database
-!exportedkeys     List all the exported keys for the specified table
-!go               Select the current connection
-!help             Print a summary of command usage
-!history          Display the command history
-!importedkeys     List all the imported keys for the specified table
-!indexes          List all the indexes for the specified table
-!isolation        Set the transaction isolation for this connection
-!list             List the current connections
-!metadata         Obtain metadata information
-!outputformat     Set the output format for displaying results
-                  (table,vertical,csv,tsv,xmlattrs,xmlelements,json)
-!properties       Connect to the database specified in the properties file(s)
-!primarykeys      List all the primary keys for the specified table
-!procedures       List all the procedures
-!quit             Exits the program
-!reconnect        Reconnect to the database
-!record           Record all output to the specified file
-!rehash           Fetch table and column names for command completion
-!rollback         Roll back the current transaction (if autocommit is off)
-!run              Run a script from the specified file
-!save             Save the current variabes and aliases
-!scan             Scan for installed JDBC drivers
-!script           Start saving a script to a file
-!set              Set a sqlline variable
-!sql              Execute a SQL command
-!tables           List all the tables in the database
-!verbose          Set verbose mode on
+!all                Execute the specified SQL against all the current
+                    connections
+!autocommit         Set autocommit mode on or off
+!batch              Start or execute a batch of statements
+!brief              Set verbose mode off
+!call               Execute a callable statement
+!close              Close the current connection to the database
+!closeall           Close all current open connections
+!columns            List all the columns for the specified table
+!commandhandler     Add a command handler
+!commit             Commit the current transaction (if autocommit is off)
+!connect            Open a new connection to the database
+!dbinfo             Give metadata information about the database
+!describe           Describe a table
+!dropall            Drop all tables in the current database
+!exportedkeys       List all the exported keys for the specified table
+!go                 Select the current connection
+!help               Print a summary of command usage
+!history            Display the command history
+!importedkeys       List all the imported keys for the specified table
+!indexes            List all the indexes for the specified table
+!isolation          Set the transaction isolation for this connection
+!list               List the current connections
+!manual             Display the SQLLine manual
+!metadata           Obtain metadata information
+!nativesql          Show the native SQL for the specified statement
+!nickname           Create a friendly name for the connection (updates command
+                    prompt)
+!outputformat       Set the output format for displaying results
+                    (table,vertical,csv,tsv,xmlattrs,xmlelements,json)
+!primarykeys        List all the primary keys for the specified table
+!procedures         List all the procedures
+!properties         Connect to the database specified in the properties file(s)
+!quit               Exits the program
+!reconnect          Reconnect to the database
+!record             Record all output to the specified file
+!rehash             Fetch table and column names for command completion
+!rollback           Roll back the current transaction (if autocommit is off)
+!run                Run a script from the specified file
+!save               Save the current variabes and aliases
+!scan               Scan for installed JDBC drivers
+!script             Start saving a script to a file
+!set                Set a sqlline variable
 
-Comments, bug reports, and patches go to mwp1@cornell.edu
+Variable        Value      Description
+=============== ========== ================================
+autoCommit      true/false Enable/disable automatic
+                           transaction commit
+autoSave        true/false Automatically save preferences
+color           true/false Control whether color is used
+                           for display
+csvDelimiter    String     Delimiter in csv outputFormat
+csvQuoteCharacter char     Quote character in
+                           csv outputFormat
+dateFormat      pattern    Format dates using
+                           SimpleDateFormat pattern
+fastConnect     true/false Skip building table/column list
+                           for tab-completion
+force           true/false Continue running script even
+                           after errors
+headerInterval  integer    The interval between which
+                           headers are displayed
+historyFile     path       File in which to save command
+                           history. Default is
+                           $HOME/.sqlline/history (UNIX,
+                           Linux, Mac OS),
+                           $HOME/sqlline/history (Windows)
+incremental     true/false Do not receive all rows from
+                           server before printing the first
+                           row. Uses fewer resources,
+                           especially for long-running
+                           queries, but column widths may
+                           be incorrect.
+isolation       LEVEL      Set transaction isolation level
+maxColumnWidth  integer    The maximum width to use when
+                           displaying columns
+maxHeight       integer    The maximum height of the
+                           terminal
+maxWidth        integer    The maximum width of the
+                           terminal
+nullValue       String     Use String in place of
+                           NULL values
+numberFormat    pattern    Format numbers using
+                           DecimalFormat pattern
+outputFormat    table/vertical/csv/tsv Format mode for
+                           result display
+propertiesFile  path       File from which SqlLine reads
+                           properties on startup; default is
+                           $HOME/.sqlline/sqlline.properties
+                           (UNIX, Linux, Mac OS),
+                           $HOME/sqlline/sqlline.properties
+                           (Windows)
+rowLimit        integer    Maximum number of rows returned
+                           from a query; zero means no
+                           limit
+showElapsedTime true/false Display execution time when
+                           verbose
+showHeader      true/false Show column names in query
+                           results
+showNestedErrs  true/false Display nested errors
+showWarnings    true/false Display connection warnings
+silent          true/false Be more silent
+timeFormat      pattern    Format times using
+                           SimpleDateFormat pattern
+timeout         integer    Query timeout in seconds; less
+                           than zero means no timeout
+timestampFormat pattern    Format timestamps using
+                           SimpleDateFormat pattern
+trimScripts     true/false Remove trailing spaces from
+                           lines read from script files
+verbose         true/false Show verbose error messages and
+                           debug info
+!sql                Execute a SQL command
+!tables             List all the tables in the database
+!typeinfo           Display the type map for the current connection
+!verbose            Set verbose mode on
+
+Comments, bug reports, and patches go to ???
 
 sqlline>
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -345,8 +345,8 @@ public class SqlLineArgsTest {
       if (i < 0) {
         break;
       }
-      if (i > 61) {
-        fail("line exceeds 61 chars: " + help.substring(0, i));
+      if (i > 71) {
+        fail("line exceeds 71 chars: " + help.substring(0, i));
       }
       help = help.substring(i);
     }


### PR DESCRIPTION
The PR provides fix for #127 
1. Update of `!help` description in `manual.txt`
2. Update of output formats in `sqlline.properties`
3. Increase the limit of line length in `!help` output as output formats take more than 61. 