### PR TITLE
Application class update

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -615,7 +615,7 @@ sqlline>
         <screen>
 sqlline> !hello
 Unknown command: hello
-sqlline> !commandhandler sqlline.commandhandler.HelloWorldCommandHandler
+sqlline> !commandhandler sqlline.extensions.HelloWorldCommandHandler
 sqlline> !hello
 HELLO WORLD
 sqlline>

--- a/src/main/java/sqlline/AbstractOutputFormat.java
+++ b/src/main/java/sqlline/AbstractOutputFormat.java
@@ -14,7 +14,7 @@ package sqlline;
 /**
  * Abstract OutputFormat.
  */
-abstract class AbstractOutputFormat implements OutputFormat {
+public abstract class AbstractOutputFormat implements OutputFormat {
   protected final SqlLine sqlLine;
 
   public AbstractOutputFormat(SqlLine sqlLine) {

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -33,13 +33,14 @@ import jline.console.completer.StringsCompleter;
  * Defines the configuration of a SQLLine application.
  *
  * <p>This class can be extended to allow customizations for:
- * known drivers, output formats, commands, information message.
+ * known drivers, output formats, commands,
+ * information message, session options.
  *
  * <p>You can pass the name of the sub-class to SQLLine
  * via the {@code -ac} command-line parameter or {@code !appconfig} command.
  *
  * <p> Use {@code !appconfig sqlline.Application} to reset
- * SQLLine application configuration to defaults at runtime.
+ * SQLLine application configuration to default at runtime.
 */
 public class Application {
 
@@ -302,7 +303,7 @@ public class Application {
       new ReflectiveCommandHandler(sqlLine, empty, "rollback"),
       new ReflectiveCommandHandler(sqlLine, empty, "help", "?"),
       new ReflectiveCommandHandler(sqlLine,
-          sqlLine.getOpts().optionCompleters(), "set"),
+          getOpts(sqlLine).optionCompleters(), "set"),
       new ReflectiveCommandHandler(sqlLine, empty, "save"),
       new ReflectiveCommandHandler(sqlLine, empty, "scan"),
       new ReflectiveCommandHandler(sqlLine, empty, "sql"),
@@ -310,6 +311,23 @@ public class Application {
       new ReflectiveCommandHandler(sqlLine, empty, "appconfig"),
     };
     return Collections.unmodifiableList(Arrays.asList(handlers));
+  }
+
+  /**
+   * Override this method to modify session options.
+   *
+   * <p>If method is not overridden, current state of options will be
+   * reset to default ({@code super.getOpts(sqlLine)}).
+   *
+   * <p>To update / leave current state, override this method
+   * and use {@code sqlLine.getOpts()}.
+   *
+   * @param sqlLine SQLLine instance
+   *
+   * @return SQLLine session options
+   */
+  public SqlLineOpts getOpts(SqlLine sqlLine) {
+    return new SqlLineOpts(sqlLine);
   }
 
   private Set<String> getMetadataMethodNames() {

--- a/src/main/java/sqlline/OutputFormat.java
+++ b/src/main/java/sqlline/OutputFormat.java
@@ -14,7 +14,7 @@ package sqlline;
 /**
  * Converts a collection of rows into text.
  */
-interface OutputFormat {
+public interface OutputFormat {
   int print(Rows rows);
 }
 

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -24,7 +24,7 @@ import jline.console.completer.StringsCompleter;
 /**
  * Session options.
  */
-class SqlLineOpts implements Completer {
+public class SqlLineOpts implements Completer {
   public static final String PROPERTY_PREFIX = "sqlline.";
   public static final String PROPERTY_NAME_EXIT =
       PROPERTY_PREFIX + "system.exit";

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -656,7 +656,7 @@ Example of "commandhandler" command
 
 sqlline> !hello
 Unknown command: hello
-sqlline> !commandhandler sqlline.commandhandler.HelloWorldCommandHandler
+sqlline> !commandhandler sqlline.extensions.HelloWorldCommandHandler
 sqlline> !hello
 HELLO WORLD
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1355,6 +1355,16 @@ public class SqlLineArgsTest {
       containsString("TABLE_CAT"));
   }
 
+  @Test
+  public void testCustomOpts() throws Throwable {
+    // nulls are displayed as custom_null
+    final String script = "!appconfig"
+      + " sqlline.extensions.CustomApplication\n"
+      + "values(null)";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+      containsString("custom_null"));
+  }
+
   // Work around compile error in JDK 1.6
   private static Matcher<String> allOf(Matcher<String> m1,
       Matcher<String> m2) {

--- a/src/test/java/sqlline/extensions/CustomApplication.java
+++ b/src/test/java/sqlline/extensions/CustomApplication.java
@@ -25,13 +25,14 @@ import sqlline.CommandHandler;
 import sqlline.OutputFormat;
 import sqlline.ReflectiveCommandHandler;
 import sqlline.SqlLine;
+import sqlline.SqlLineOpts;
 
 /**
  * Sub-class of {@link Application} that is used to test custom
  * application configuration.
  *
  * <p>Overrides information message, output formats, commands,
- * connection url examples.
+ * connection url examples, session options.
  */
 public class CustomApplication extends Application {
 
@@ -83,5 +84,12 @@ public class CustomApplication extends Application {
   @Override
   public Collection<String> getConnectionUrlExamples() {
     return Collections.singletonList("my_custom_url_connection_example");
+  }
+
+  @Override
+  public SqlLineOpts getOpts(SqlLine sqlLine) {
+    SqlLineOpts opts = sqlLine.getOpts();
+    opts.setNullValue("custom_null");
+    return opts;
   }
 }

--- a/src/test/java/sqlline/extensions/CustomApplication.java
+++ b/src/test/java/sqlline/extensions/CustomApplication.java
@@ -1,0 +1,87 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline.extensions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import jline.console.completer.StringsCompleter;
+import sqlline.Application;
+import sqlline.CommandHandler;
+import sqlline.OutputFormat;
+import sqlline.ReflectiveCommandHandler;
+import sqlline.SqlLine;
+
+/**
+ * Sub-class of {@link Application} that is used to test custom
+ * application configuration.
+ *
+ * <p>Overrides information message, output formats, commands,
+ * connection url examples.
+ */
+public class CustomApplication extends Application {
+
+  public static final String CUSTOM_INFO_MESSAGE = "my_custom_info_message";
+
+  @Override
+  public String getInfoMessage() {
+    return CUSTOM_INFO_MESSAGE;
+  }
+
+  @Override
+  public Map<String, OutputFormat> getOutputFormats(SqlLine sqlLine) {
+    final Map<String, OutputFormat> outputFormats =
+      new HashMap<String, OutputFormat>(
+        sqlLine.getOutputFormats());
+    outputFormats.remove("json");
+    return outputFormats;
+  }
+
+  @Override
+  public Collection<CommandHandler> getCommandHandlers(SqlLine sqlLine) {
+    final List<CommandHandler> commandHandlers =
+      new ArrayList<CommandHandler>(
+        sqlLine.getCommandHandlers());
+    final Iterator<CommandHandler> iterator =
+      commandHandlers.iterator();
+    while (iterator.hasNext()) {
+      CommandHandler next = iterator.next();
+      List<String> names = next.getNames();
+      if (names.contains("tables")
+        || names.contains("connect")
+        || names.contains("outputformat")) {
+        iterator.remove();
+      }
+    }
+
+    commandHandlers.add(new ReflectiveCommandHandler(sqlLine,
+      new StringsCompleter(getConnectionUrlExamples()),
+      "connect", "open"));
+
+
+    commandHandlers.add(new ReflectiveCommandHandler(sqlLine,
+      new StringsCompleter(getOutputFormats(sqlLine).keySet()),
+      "outputformat"));
+
+    return commandHandlers;
+  }
+
+  @Override
+  public Collection<String> getConnectionUrlExamples() {
+    return Collections.singletonList("my_custom_url_connection_example");
+  }
+}

--- a/src/test/java/sqlline/extensions/HelloWorld2CommandHandler.java
+++ b/src/test/java/sqlline/extensions/HelloWorld2CommandHandler.java
@@ -9,7 +9,7 @@
 //
 // http://opensource.org/licenses/BSD-3-Clause
 */
-package sqlline.commandhandler;
+package sqlline.extensions;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/sqlline/extensions/HelloWorldCommandHandler.java
+++ b/src/test/java/sqlline/extensions/HelloWorldCommandHandler.java
@@ -9,7 +9,7 @@
 //
 // http://opensource.org/licenses/BSD-3-Clause
 */
-package sqlline.commandhandler;
+package sqlline.extensions;
 
 import java.util.Collections;
 

--- a/src/test/java/sqlline/extensions/package-info.java
+++ b/src/test/java/sqlline/extensions/package-info.java
@@ -15,7 +15,8 @@
  * Unit tests for SQLLine, the JDBC shell
  * to check methods visibility between packages.
  * (required for command handlers,
- * output formats, application extensions etc).
+ * output formats, application, session options
+ * extensions etc).
  */
 package sqlline.extensions;
 

--- a/src/test/java/sqlline/extensions/package-info.java
+++ b/src/test/java/sqlline/extensions/package-info.java
@@ -13,8 +13,10 @@
 /**
  * A different package for
  * Unit tests for SQLLine, the JDBC shell
- * to check methods (required for command handlers) visibility between packages.
+ * to check methods visibility between packages.
+ * (required for command handlers,
+ * output formats, application extensions etc).
  */
-package sqlline.commandhandler;
+package sqlline.extensions;
 
 // End package-info.java


### PR DESCRIPTION
- Changes discussed in PR.

1. Renamed commandhandler package to extensions.
2. Moved CustomApplication to extensions package.
3. OutputFormat and AbstractOutputFormat are made public.
4. Formats and command handlers holders are made immutable:
4.1. Config class in Sqlline wraps all given constructor parameters into unmodifiable objects.
4.2. Two clone methods were added into Config class to clone its content when formats / command handlers are changed.
4.3. Two methods to update formats / command handlers are added into Sqlline class which clones and re-assigns Config.
5. Added unit test to demonstrate how application configuration can be reset at runtime.
6. Updated javadocs.

- Added possibility to override SqlLine session options in Application.