### PR TITLE
[SQLLINE-172] Update travis.yml to cope with oraclejdk10 issue on travi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,35 @@
 # Configuration for Travis CI
+# This version of travis is based on the Apache Calcite travis.yml.
 language: java
-jdk:
-  - oraclejdk11
-  - oraclejdk10
-  - oraclejdk9
-  - oraclejdk8
+matrix:
+  fast_finish: true
+  include:
+  - env: IMAGE=maven:3-jdk-11 JDOC=Y
+  - env: IMAGE=maven:3-jdk-10
+  - env: IMAGE=maven:3-jdk-9
+  - env: IMAGE=maven:3-jdk-8 JDOC=Y
 branches:
   only:
     - master
+env:
+  global:
+  - DOCKERRUN="docker run -it --rm -v $PWD:/src -v $HOME/.m2:/root/.m2 -w /src"
+services:
+- docker
+before_install:
+- docker pull $IMAGE
+install:
+# Print the Maven version, skip tests and javadoc
+- $DOCKERRUN $IMAGE mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Djavax.net.ssl.trustStorePassword=changeit -B -V
+script:
+# Print surefire output to the console instead of files
+- unset _JAVA_OPTIONS
+- if [ $JDOC = "Y" ]; then export JDOC=javadoc:javadoc; fi
+- $DOCKERRUN $IMAGE mvn -Dcheckstyle.skip -Dsurefire.useFile=false -Dsurefire.threadCount=1 -Dsurefire.perCoreThreadCount=false -Djavax.net.ssl.trustStorePassword=changeit test $JDOC
+git:
+  depth: 10000
+sudo: required
 cache:
   directories:
-    - $HOME/.m2
-git:
-  depth: 1000
+  - $HOME/.m2
 # End .travis.yml


### PR DESCRIPTION
The PR suggests to use travis.yml with docker images of different jvms to cope with problems like 

> travis could not download oraclejdk10

based on existing version from Apache Calcite.
Fixes #172 