### PR TITLE
[SQLLINE-164] Sql syntax highlighting support

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -2765,6 +2765,17 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           Defaults to <literal>false</literal>.
         </para>
       </sect1>
+      <sect1 id="setting_colorscheme">
+        <title>colorscheme</title>
+        <para>
+            If <literal>chester</literal>/<literal>dark</literal>
+            /<literal>dracula</literal>/<literal>light</literal>
+            /<literal>ozbsidian</literal>/<literal>solarized</literal>
+            /<literal>vs2010</literal>,
+            then this scheme will be used for command/sql syntax highlighting.
+            If <literal>default</literal> then there is no syntax highlighting.
+        </para>
+      </sect1>
       <sect1 id="setting_dateformat">
         <title>dateformat</title>
         <para>

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -381,10 +381,10 @@ public class Application {
     private static final AttributedStyle DOUBLE_QUOTED_STYLE =
         AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN);
     private static final AttributedStyle COMMENTED_STYLE =
-        AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT);
+        AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT).italic();
     private static final AttributedStyle NUMBERS_STYLE =
         AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
-    private static final AttributedStyle DEFAULT_STYLE =
+    public static final AttributedStyle DEFAULT_STYLE =
         AttributedStyle.DEFAULT.foreground(AttributedStyle.WHITE);
     private static final AttributedStyle COMMAND_STYLE =
         AttributedStyle.DEFAULT.bold();

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -30,6 +30,7 @@ import java.util.TreeSet;
 import org.jline.builtins.Completers.FileNameCompleter;
 import org.jline.reader.Completer;
 import org.jline.reader.impl.completer.StringsCompleter;
+import org.jline.utils.AttributedStyle;
 
 /**
  * Defines the configuration of a SQLLine application.
@@ -366,6 +367,49 @@ public class Application {
         "TRANSACTION_SERIALIZABLE");
   }
 
+  public HightlightConfig getHighlightConfig() {
+    return new HightlightConfig();
+  }
+
+  /** Cache of configuration settings that come from
+   * {@link Application}. */
+  public static class HightlightConfig {
+    private static final AttributedStyle SQL_KEYWORD_STYLE = AttributedStyle.BOLD.foreground(AttributedStyle.BLUE);
+    private static final AttributedStyle QUOTED_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN);
+    private static final AttributedStyle DOUBLE_QUOTED_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN);
+    private static final AttributedStyle COMMENTED_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT);
+    private static final AttributedStyle NUMBERS_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
+    private static final AttributedStyle DEFAULT_STYLE = AttributedStyle.DEFAULT;
+    private static final AttributedStyle COMMAND_STYLE = AttributedStyle.DEFAULT.bold();
+
+    public AttributedStyle getSqlKeywordStyle() {
+      return SQL_KEYWORD_STYLE;
+    }
+
+    public AttributedStyle getQuotedStyle() {
+      return QUOTED_STYLE;
+    }
+
+    public AttributedStyle getDoubleQuotedStyle() {
+      return DOUBLE_QUOTED_STYLE;
+    }
+
+    public AttributedStyle getCommentedStyle() {
+      return COMMENTED_STYLE;
+    }
+
+    public AttributedStyle getNumbersStyle() {
+      return NUMBERS_STYLE;
+    }
+
+    public AttributedStyle getDefaultStyle() {
+      return DEFAULT_STYLE;
+    }
+
+    public AttributedStyle getCommandStyle() {
+      return COMMAND_STYLE;
+    }
+  }
 }
 
 // End Application.java

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -367,20 +367,27 @@ public class Application {
         "TRANSACTION_SERIALIZABLE");
   }
 
-  public HightlightConfig getHighlightConfig() {
-    return new HightlightConfig();
+  public HighlightConfig getHighlightConfig() {
+    return new HighlightConfig();
   }
 
   /** Cache of configuration settings that come from
    * {@link Application}. */
-  public static class HightlightConfig {
-    private static final AttributedStyle SQL_KEYWORD_STYLE = AttributedStyle.BOLD.foreground(AttributedStyle.BLUE);
-    private static final AttributedStyle QUOTED_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN);
-    private static final AttributedStyle DOUBLE_QUOTED_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN);
-    private static final AttributedStyle COMMENTED_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT);
-    private static final AttributedStyle NUMBERS_STYLE = AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
-    private static final AttributedStyle DEFAULT_STYLE = AttributedStyle.DEFAULT;
-    private static final AttributedStyle COMMAND_STYLE = AttributedStyle.DEFAULT.bold();
+  public static class HighlightConfig {
+    private static final AttributedStyle SQL_KEYWORD_STYLE =
+        AttributedStyle.BOLD.foreground(AttributedStyle.BLUE);
+    private static final AttributedStyle QUOTED_STYLE =
+        AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN);
+    private static final AttributedStyle DOUBLE_QUOTED_STYLE =
+        AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN);
+    private static final AttributedStyle COMMENTED_STYLE =
+        AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT);
+    private static final AttributedStyle NUMBERS_STYLE =
+        AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
+    private static final AttributedStyle DEFAULT_STYLE =
+        AttributedStyle.DEFAULT.foreground(AttributedStyle.WHITE);
+    private static final AttributedStyle COMMAND_STYLE =
+        AttributedStyle.DEFAULT.bold();
 
     public AttributedStyle getSqlKeywordStyle() {
       return SQL_KEYWORD_STYLE;

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -30,7 +30,6 @@ import java.util.TreeSet;
 import org.jline.builtins.Completers.FileNameCompleter;
 import org.jline.reader.Completer;
 import org.jline.reader.impl.completer.StringsCompleter;
-import org.jline.utils.AttributedStyle;
 
 /**
  * Defines the configuration of a SQLLine application.
@@ -367,55 +366,8 @@ public class Application {
         "TRANSACTION_SERIALIZABLE");
   }
 
-  public HighlightConfig getHighlightConfig() {
-    return new HighlightConfig();
-  }
-
-  /** Cache of configuration settings that come from
-   * {@link Application}. */
-  public static class HighlightConfig {
-    private static final AttributedStyle SQL_KEYWORD_STYLE =
-        AttributedStyle.BOLD.foreground(AttributedStyle.BLUE);
-    private static final AttributedStyle QUOTED_STYLE =
-        AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN);
-    private static final AttributedStyle DOUBLE_QUOTED_STYLE =
-        AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN);
-    private static final AttributedStyle COMMENTED_STYLE =
-        AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT).italic();
-    private static final AttributedStyle NUMBERS_STYLE =
-        AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
-    public static final AttributedStyle DEFAULT_STYLE =
-        AttributedStyle.DEFAULT.foreground(AttributedStyle.WHITE);
-    private static final AttributedStyle COMMAND_STYLE =
-        AttributedStyle.DEFAULT.bold();
-
-    public AttributedStyle getSqlKeywordStyle() {
-      return SQL_KEYWORD_STYLE;
-    }
-
-    public AttributedStyle getQuotedStyle() {
-      return QUOTED_STYLE;
-    }
-
-    public AttributedStyle getDoubleQuotedStyle() {
-      return DOUBLE_QUOTED_STYLE;
-    }
-
-    public AttributedStyle getCommentedStyle() {
-      return COMMENTED_STYLE;
-    }
-
-    public AttributedStyle getNumbersStyle() {
-      return NUMBERS_STYLE;
-    }
-
-    public AttributedStyle getDefaultStyle() {
-      return DEFAULT_STYLE;
-    }
-
-    public AttributedStyle getCommandStyle() {
-      return COMMAND_STYLE;
-    }
+  public Map<String, HighlightStyle> getName2HighlightStyle() {
+    return HighlightStyle.getName2highlightStyle();
   }
 }
 

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -25,6 +25,7 @@ public enum BuiltInProperty implements SqlLineProperty {
 
   AUTO_COMMIT("autoCommit", Type.BOOLEAN, true),
   AUTO_SAVE("autoSave", Type.BOOLEAN, false),
+  COLOR_SCHEME("colorScheme", Type.STRING, DEFAULT),
   COLOR("color", Type.BOOLEAN, false),
   CSV_DELIMITER("csvDelimiter", Type.STRING, ","),
 

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -171,7 +171,7 @@ class DatabaseConnection {
     return true;
   }
 
-  public void addHighlighter(SqlLineHighlighter highlighter) {
+  public void setHighlighter(SqlLineHighlighter highlighter) {
     this.highlighter = highlighter;
   }
 
@@ -197,7 +197,9 @@ class DatabaseConnection {
           sqlLine.output(
               sqlLine.loc("closing", connection.getClass().getName()));
           connection.close();
-          highlighter.removeConnection(connection);
+          if (highlighter != null) {
+            highlighter.removeConnection(connection);
+          }
         }
       } catch (Exception e) {
         sqlLine.handleException(e);

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -32,6 +32,7 @@ class DatabaseConnection {
   private String nickname;
   private Schema schema = null;
   private Completer sqlCompleter = null;
+  private SqlLineHighlighter highlighter;
 
   DatabaseConnection(SqlLine sqlLine, String driver, String url,
       String username, String password, Properties properties) {
@@ -170,6 +171,10 @@ class DatabaseConnection {
     return true;
   }
 
+  public void addHighlighter(SqlLineHighlighter highlighter) {
+    this.highlighter = highlighter;
+  }
+
   public Connection getConnection() throws SQLException {
     if (connection != null) {
       return connection;
@@ -192,6 +197,7 @@ class DatabaseConnection {
           sqlLine.output(
               sqlLine.loc("closing", connection.getClass().getName()));
           connection.close();
+          highlighter.removeConnection(this);
         }
       } catch (Exception e) {
         sqlLine.handleException(e);

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -197,7 +197,7 @@ class DatabaseConnection {
           sqlLine.output(
               sqlLine.loc("closing", connection.getClass().getName()));
           connection.close();
-          highlighter.removeConnection(this);
+          highlighter.removeConnection(connection);
         }
       } catch (Exception e) {
         sqlLine.handleException(e);

--- a/src/main/java/sqlline/HighlightStyle.java
+++ b/src/main/java/sqlline/HighlightStyle.java
@@ -141,7 +141,7 @@ public class HighlightStyle {
     return quotedStyle;
   }
 
-  public AttributedStyle getDoubleQuotedStyle() {
+  public AttributedStyle getSqlIdentifierStyle() {
     return doubleQuotedStyle;
   }
 

--- a/src/main/java/sqlline/HighlightStyle.java
+++ b/src/main/java/sqlline/HighlightStyle.java
@@ -1,0 +1,163 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Class to specify colors and styles while highlighting.
+ */
+public class HighlightStyle {
+  private static final AttributedStyle GREEN =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN);
+  private static final AttributedStyle CYAN =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN);
+  private static final AttributedStyle BRIGHT =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT);
+  private static final AttributedStyle YELLOW =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
+  private static final AttributedStyle WHITE =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.WHITE);
+  private static final AttributedStyle BLACK =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.BLACK);
+  private static final AttributedStyle MAGENTA =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.MAGENTA);
+  private static final AttributedStyle RED =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.RED);
+  private static final AttributedStyle BLUE =
+      AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE);
+
+  private static final AttributedStyle BOLD_GREEN =
+      AttributedStyle.BOLD.foreground(AttributedStyle.GREEN);
+  private static final AttributedStyle BOLD_CYAN =
+      AttributedStyle.BOLD.foreground(AttributedStyle.CYAN);
+  private static final AttributedStyle BOLD_BRIGHT =
+      AttributedStyle.BOLD.foreground(AttributedStyle.BRIGHT);
+  private static final AttributedStyle BOLD_YELLOW =
+      AttributedStyle.BOLD.foreground(AttributedStyle.YELLOW);
+  private static final AttributedStyle BOLD_WHITE =
+      AttributedStyle.BOLD.foreground(AttributedStyle.WHITE);
+  private static final AttributedStyle BOLD_BLACK =
+      AttributedStyle.BOLD.foreground(AttributedStyle.BLACK);
+  private static final AttributedStyle BOLD_MAGENTA =
+      AttributedStyle.BOLD.foreground(AttributedStyle.MAGENTA);
+  private static final AttributedStyle BOLD_RED =
+      AttributedStyle.BOLD.foreground(AttributedStyle.RED);
+  private static final AttributedStyle BOLD_BLUE =
+      AttributedStyle.BOLD.foreground(AttributedStyle.BLUE);
+
+  private static final AttributedStyle ITALIC_GREEN =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.GREEN);
+  private static final AttributedStyle ITALIC_CYAN =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.CYAN);
+  private static final AttributedStyle ITALIC_BRIGHT =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.BRIGHT);
+  private static final AttributedStyle ITALIC_YELLOW =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.YELLOW);
+  private static final AttributedStyle ITALIC_WHITE =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.WHITE);
+  private static final AttributedStyle ITALIC_BLACK =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.BLACK);
+  private static final AttributedStyle ITALIC_MAGENTA =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.MAGENTA);
+  private static final AttributedStyle ITALIC_RED =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.RED);
+  private static final AttributedStyle ITALIC_BLUE =
+      AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.BLUE);
+
+  private static final AttributedStyle COMMAND_STYLE =
+      AttributedStyle.DEFAULT.bold();
+
+  static final Map<String, HighlightStyle> NAME2HIGHLIGHT_STYLE =
+      new HashMap<String, HighlightStyle>() {{
+          put("dark", new HighlightStyle(
+              BOLD_BLUE, BOLD_WHITE, GREEN, CYAN,
+              ITALIC_BRIGHT, YELLOW, WHITE));
+          put("light", new HighlightStyle(
+              BOLD_RED, BOLD_BLACK, GREEN, CYAN,
+              ITALIC_BRIGHT, YELLOW, BLACK));
+          put("chester", new HighlightStyle(
+              BOLD_BLUE, BOLD_WHITE, RED, CYAN, ITALIC_GREEN, YELLOW, WHITE));
+          put("dracula", new HighlightStyle(
+              BOLD_MAGENTA, BOLD_WHITE, GREEN,
+              RED, ITALIC_CYAN, YELLOW, WHITE));
+          put("solarized", new HighlightStyle(
+              BOLD_YELLOW, BOLD_BLUE, GREEN, RED, ITALIC_BRIGHT, CYAN, BLUE));
+          put("vs2010", new HighlightStyle(
+              BOLD_BLUE, BOLD_WHITE, RED, MAGENTA,
+              ITALIC_GREEN, BRIGHT, WHITE));
+          put("ozbsidian", new HighlightStyle(
+              BOLD_GREEN, BOLD_WHITE, RED, MAGENTA,
+              ITALIC_BRIGHT, YELLOW, WHITE));
+      }};
+
+  private final AttributedStyle keyWordsStyle;
+  private final AttributedStyle commandsStyle;
+  private final AttributedStyle quotedStyle;
+  private final AttributedStyle doubleQuotedStyle;
+  private final AttributedStyle commentedStyle;
+  private final AttributedStyle numberStyle;
+  private final AttributedStyle defaultStyle;
+
+  public HighlightStyle(AttributedStyle keyWordsStyle,
+                        AttributedStyle commandsStyle,
+                        AttributedStyle quotedStyle,
+                        AttributedStyle doubleQuotedStyle,
+                        AttributedStyle commentedStyle,
+                        AttributedStyle numberStyle,
+                        AttributedStyle defaultStyle) {
+    this.keyWordsStyle = keyWordsStyle;
+    this.commandsStyle = commandsStyle;
+    this.quotedStyle = quotedStyle;
+    this.doubleQuotedStyle = doubleQuotedStyle;
+    this.commentedStyle = commentedStyle;
+    this.numberStyle = numberStyle;
+    this.defaultStyle = defaultStyle;
+  }
+
+  public static Map<String, HighlightStyle> getName2highlightStyle() {
+    return NAME2HIGHLIGHT_STYLE;
+  }
+
+  public AttributedStyle getSqlKeywordStyle() {
+    return keyWordsStyle;
+  }
+
+  public AttributedStyle getQuotedStyle() {
+    return quotedStyle;
+  }
+
+  public AttributedStyle getDoubleQuotedStyle() {
+    return doubleQuotedStyle;
+  }
+
+  public AttributedStyle getCommentedStyle() {
+    return commentedStyle;
+  }
+
+  public AttributedStyle getNumbersStyle() {
+    return numberStyle;
+  }
+
+  public AttributedStyle getDefaultStyle() {
+    return defaultStyle;
+  }
+
+  public AttributedStyle getCommandStyle() {
+    return commandsStyle;
+  }
+}
+
+// End HighlightStyle.java

--- a/src/main/java/sqlline/HighlightStyle.java
+++ b/src/main/java/sqlline/HighlightStyle.java
@@ -108,7 +108,7 @@ public class HighlightStyle {
   private final AttributedStyle keyWordsStyle;
   private final AttributedStyle commandsStyle;
   private final AttributedStyle quotedStyle;
-  private final AttributedStyle doubleQuotedStyle;
+  private final AttributedStyle sqlIdentifierStyle;
   private final AttributedStyle commentedStyle;
   private final AttributedStyle numberStyle;
   private final AttributedStyle defaultStyle;
@@ -116,14 +116,14 @@ public class HighlightStyle {
   public HighlightStyle(AttributedStyle keyWordsStyle,
                         AttributedStyle commandsStyle,
                         AttributedStyle quotedStyle,
-                        AttributedStyle doubleQuotedStyle,
+                        AttributedStyle sqlIdentifierStyle,
                         AttributedStyle commentedStyle,
                         AttributedStyle numberStyle,
                         AttributedStyle defaultStyle) {
     this.keyWordsStyle = keyWordsStyle;
     this.commandsStyle = commandsStyle;
     this.quotedStyle = quotedStyle;
-    this.doubleQuotedStyle = doubleQuotedStyle;
+    this.sqlIdentifierStyle = sqlIdentifierStyle;
     this.commentedStyle = commentedStyle;
     this.numberStyle = numberStyle;
     this.defaultStyle = defaultStyle;
@@ -142,7 +142,7 @@ public class HighlightStyle {
   }
 
   public AttributedStyle getSqlIdentifierStyle() {
-    return doubleQuotedStyle;
+    return sqlIdentifierStyle;
   }
 
   public AttributedStyle getCommentedStyle() {

--- a/src/main/java/sqlline/HighlightStyle.java
+++ b/src/main/java/sqlline/HighlightStyle.java
@@ -77,9 +77,6 @@ public class HighlightStyle {
   private static final AttributedStyle ITALIC_BLUE =
       AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.BLUE);
 
-  private static final AttributedStyle COMMAND_STYLE =
-      AttributedStyle.DEFAULT.bold();
-
   static final Map<String, HighlightStyle> NAME2HIGHLIGHT_STYLE =
       new HashMap<String, HighlightStyle>() {{
           put("dark", new HighlightStyle(
@@ -88,6 +85,9 @@ public class HighlightStyle {
           put("light", new HighlightStyle(
               BOLD_RED, BOLD_BLACK, GREEN, CYAN,
               ITALIC_BRIGHT, YELLOW, BLACK));
+          // The next four schemes inspired by
+          // https://github.com/Gillisdc/sqldeveloper-syntax-highlighting
+          // not the same but more or less similar
           put("chester", new HighlightStyle(
               BOLD_BLUE, BOLD_WHITE, RED, CYAN, ITALIC_GREEN, YELLOW, WHITE));
           put("dracula", new HighlightStyle(
@@ -98,6 +98,8 @@ public class HighlightStyle {
           put("vs2010", new HighlightStyle(
               BOLD_BLUE, BOLD_WHITE, RED, MAGENTA,
               ITALIC_GREEN, BRIGHT, WHITE));
+          // inspired by https://github.com/ozmoroz/ozbsidian-sqldeveloper
+          // not the same but more or less similar
           put("ozbsidian", new HighlightStyle(
               BOLD_GREEN, BOLD_WHITE, RED, MAGENTA,
               ITALIC_BRIGHT, YELLOW, WHITE));

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -370,27 +370,38 @@ public class SqlLine {
         if (i == args.length - 1) {
           return Status.ARGS;
         }
-        if (args[i].equals("-d")) {
+        switch (args[i]) {
+        case "-d":
           driver = args[++i];
-        } else if (args[i].equals("-ch")) {
+          break;
+        case "-ch":
           commandHandler = args[++i];
-        } else if (args[i].equals("-n")) {
+          break;
+        case "-n":
           user = args[++i];
-        } else if (args[i].equals("-p")) {
+          break;
+        case "-p":
           pass = args[++i];
-        } else if (args[i].equals("-u")) {
+          break;
+        case "-u":
           url = args[++i];
-        } else if (args[i].equals("-e")) {
+          break;
+        case "-e":
           commands.add(args[++i]);
-        } else if (args[i].equals("-f")) {
+          break;
+        case "-f":
           getOpts().setRun(args[++i]);
-        } else if (args[i].equals("-log")) {
+          break;
+        case "-log":
           logFile = args[++i];
-        } else if (args[i].equals("-nn")) {
+          break;
+        case "-nn":
           nickname = args[++i];
-        } else if (args[i].equals("-ac")) {
+          break;
+        case "-ac":
           appConfig = args[++i];
-        } else {
+          break;
+        default:
           return Status.ARGS;
         }
       } else {
@@ -1889,8 +1900,8 @@ public class SqlLine {
     this.appConfig = new Config(application);
   }
 
-  public Application.HighlightConfig getHighlightConfig() {
-    return appConfig.highlightConfig;
+  public HighlightStyle getHighlightStyle() {
+    return appConfig.name2highlightStyle.get(getOpts().getColorScheme());
   }
 
   public Collection<CommandHandler> getCommandHandlers() {
@@ -1923,42 +1934,42 @@ public class SqlLine {
     final SqlLineOpts opts;
     final Collection<CommandHandler> commandHandlers;
     final Map<String, OutputFormat> formats;
-    final Application.HighlightConfig highlightConfig;
+    final Map<String, HighlightStyle> name2highlightStyle;
     Config(Application application) {
       this(application.initDrivers(),
           application.getOpts(SqlLine.this),
           application.getCommandHandlers(SqlLine.this),
           application.getOutputFormats(SqlLine.this),
-          application.getHighlightConfig());
+          application.getName2HighlightStyle());
     }
 
     Config(Collection<String> knownDrivers,
         SqlLineOpts opts,
         Collection<CommandHandler> commandHandlers,
         Map<String, OutputFormat> formats,
-        Application.HighlightConfig highlightConfig) {
+        Map<String, HighlightStyle> name2HighlightStyle) {
       this.knownDrivers = Collections.unmodifiableSet(
           new HashSet<>(knownDrivers));
       this.opts = opts;
       this.commandHandlers = Collections.unmodifiableList(
           new ArrayList<>(commandHandlers));
       this.formats = Collections.unmodifiableMap(formats);
-      this.highlightConfig = highlightConfig;
+      this.name2highlightStyle = name2HighlightStyle;
     }
 
     Config withCommandHandlers(Collection<CommandHandler> commandHandlers) {
       return new Config(this.knownDrivers, this.opts,
-          commandHandlers, this.formats, this.highlightConfig);
+          commandHandlers, this.formats, this.name2highlightStyle);
     }
 
     Config withFormats(Map<String, OutputFormat> formats) {
       return new Config(this.knownDrivers, this.opts,
-          this.commandHandlers, formats, this.highlightConfig);
+          this.commandHandlers, formats, this.name2highlightStyle);
     }
 
     Config withOpts(SqlLineOpts opts) {
       return new Config(this.knownDrivers, opts,
-          this.commandHandlers, this.formats, this.highlightConfig);
+          this.commandHandlers, this.formats, this.name2highlightStyle);
     }
   }
 }

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -589,18 +589,16 @@ public class SqlLine {
 
     LineReaderBuilder lineReaderBuilder = LineReaderBuilder.builder()
         .terminal(terminal)
-        .parser(new SqlLineParser(this)
-            .eofOnEscapedNewLine(true)
-            .eofOnUnclosedQuote(true))
+        .parser(new SqlLineParser(this))
         .variable(LineReader.HISTORY_FILE, getOpts().getHistoryFile())
         .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
     final LineReader lineReader = inputStream == null
-      ? lineReaderBuilder
+        ? lineReaderBuilder
           .appName("sqlline")
           .completer(new SqlLineCompleter(this))
           .highlighter(new SqlLineHighlighter(this))
           .build()
-      : lineReaderBuilder.build();
+        : lineReaderBuilder.build();
 
     fileHistory.attach(lineReader);
     setLineReader(lineReader);
@@ -1891,8 +1889,8 @@ public class SqlLine {
     this.appConfig = new Config(application);
   }
 
-  public Application.HightlightConfig getHighlightConfig() {
-    return appConfig.hightlightConfig;
+  public Application.HighlightConfig getHighlightConfig() {
+    return appConfig.highlightConfig;
   }
 
   public Collection<CommandHandler> getCommandHandlers() {
@@ -1925,7 +1923,7 @@ public class SqlLine {
     final SqlLineOpts opts;
     final Collection<CommandHandler> commandHandlers;
     final Map<String, OutputFormat> formats;
-    final Application.HightlightConfig hightlightConfig;
+    final Application.HighlightConfig highlightConfig;
     Config(Application application) {
       this(application.initDrivers(),
           application.getOpts(SqlLine.this),
@@ -1938,29 +1936,29 @@ public class SqlLine {
         SqlLineOpts opts,
         Collection<CommandHandler> commandHandlers,
         Map<String, OutputFormat> formats,
-        Application.HightlightConfig hightlightConfig) {
+        Application.HighlightConfig highlightConfig) {
       this.knownDrivers = Collections.unmodifiableSet(
           new HashSet<>(knownDrivers));
       this.opts = opts;
       this.commandHandlers = Collections.unmodifiableList(
           new ArrayList<>(commandHandlers));
       this.formats = Collections.unmodifiableMap(formats);
-      this.hightlightConfig = hightlightConfig;
+      this.highlightConfig = highlightConfig;
     }
 
     Config withCommandHandlers(Collection<CommandHandler> commandHandlers) {
       return new Config(this.knownDrivers, this.opts,
-          commandHandlers, this.formats, this.hightlightConfig);
+          commandHandlers, this.formats, this.highlightConfig);
     }
 
     Config withFormats(Map<String, OutputFormat> formats) {
       return new Config(this.knownDrivers, this.opts,
-          this.commandHandlers, formats, this.hightlightConfig);
+          this.commandHandlers, formats, this.highlightConfig);
     }
 
     Config withOpts(SqlLineOpts opts) {
       return new Config(this.knownDrivers, opts,
-          this.commandHandlers, this.formats, this.hightlightConfig);
+          this.commandHandlers, this.formats, this.highlightConfig);
     }
   }
 }

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -370,38 +370,27 @@ public class SqlLine {
         if (i == args.length - 1) {
           return Status.ARGS;
         }
-        switch (args[i]) {
-        case "-d":
+        if (args[i].equals("-d")) {
           driver = args[++i];
-          break;
-        case "-ch":
+        } else if (args[i].equals("-ch")) {
           commandHandler = args[++i];
-          break;
-        case "-n":
+        } else if (args[i].equals("-n")) {
           user = args[++i];
-          break;
-        case "-p":
+        } else if (args[i].equals("-p")) {
           pass = args[++i];
-          break;
-        case "-u":
+        } else if (args[i].equals("-u")) {
           url = args[++i];
-          break;
-        case "-e":
+        } else if (args[i].equals("-e")) {
           commands.add(args[++i]);
-          break;
-        case "-f":
+        } else if (args[i].equals("-f")) {
           getOpts().setRun(args[++i]);
-          break;
-        case "-log":
+        } else if (args[i].equals("-log")) {
           logFile = args[++i];
-          break;
-        case "-nn":
+        } else if (args[i].equals("-nn")) {
           nickname = args[++i];
-          break;
-        case "-ac":
+        } else if (args[i].equals("-ac")) {
           appConfig = args[++i];
-          break;
-        default:
+        } else {
           return Status.ARGS;
         }
       } else {

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -587,7 +587,7 @@ public class SqlLine {
       getOpts().set(BuiltInProperty.MAX_HEIGHT, terminal.getHeight());
     }
 
-    LineReaderBuilder lineReaderBuilder = LineReaderBuilder.builder()
+    final LineReaderBuilder lineReaderBuilder = LineReaderBuilder.builder()
         .terminal(terminal)
         .parser(new SqlLineParser(this))
         .variable(LineReader.HISTORY_FILE, getOpts().getHistoryFile())

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -189,8 +189,11 @@ public class SqlLineHighlighter extends DefaultHighlighter {
     }
 
     AttributedStringBuilder sb = new AttributedStringBuilder();
-    final int commandStart = buffer.indexOf(SqlLine.COMMAND_PREFIX);
-    final int commandEnd = buffer.indexOf(' ', commandStart);
+    final int commandStart = command
+        ? buffer.indexOf(SqlLine.COMMAND_PREFIX) : -1;
+    final int commandEnd = command
+        ? buffer.indexOf(' ', commandStart) : -1;
+
     final Application.HighlightConfig highlightConfig =
         sqlLine.getHighlightConfig();
     for (int i = 0; i < buffer.length(); i++) {
@@ -221,6 +224,9 @@ public class SqlLineHighlighter extends DefaultHighlighter {
       if (i == commandStart && command) {
         sb.style(highlightConfig.getCommandStyle());
       }
+      if (i == commandEnd) {
+        sb.style(highlightConfig.getDefaultStyle());
+      }
       if (i >= underlineStart && i <= underlineEnd) {
         sb.style(sb.style().underline());
       }
@@ -247,10 +253,6 @@ public class SqlLineHighlighter extends DefaultHighlighter {
       if (i == negativeEnd) {
         sb.style(sb.style().inverseOff());
       }
-      if (i == commandEnd) {
-        sb.style(highlightConfig.getDefaultStyle());
-      }
-
     }
     return sb.toAttributedString();
   }
@@ -262,7 +264,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
         || !isCommandPresent;
   }
 
-  protected int handleDoubleQuotes(
+  private int handleDoubleQuotes(
       String buffer, BitSet doubleQuoteBitSet, int pos) {
     int end = buffer.indexOf('"', pos + 1);
     end = end == -1 ? buffer.length() - 1 : end;
@@ -271,7 +273,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
     return pos;
   }
 
-  protected int handleNumbers(String buffer, BitSet numberBitSet, int pos) {
+  private int handleNumbers(String buffer, BitSet numberBitSet, int pos) {
     int end = pos + 1;
     while (end < buffer.length() && Character.isDigit(buffer.charAt(end))) {
       end++;
@@ -314,7 +316,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
     return pos;
   }
 
-  protected int handleSqlSingleQuotes(
+  private int handleSqlSingleQuotes(
       String buffer, BitSet quoteBitSet, int pos) {
     int end;
     int quoteCounter = 1;

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -20,6 +20,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
@@ -227,6 +228,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
             ? getDefaultSqlIdentifierQuote() : sqlIdentifier;
         HighlightRule rule =
             new HighlightRule(connectionSQLKeyWords, sqlIdentifier);
+        databaseConnection.setHighlighter(this);
         connection2rules.put(databaseConnection.connection, rule);
         return rule;
       } else if (databaseConnection != null) {
@@ -544,13 +546,12 @@ public class SqlLineHighlighter extends DefaultHighlighter {
   }
 
   /**
-   * Check if the connection is present in connection2rules map.
+   * Returns the copy of map.
    * The only purpose of this method is testing.
-   * @param connection connection to check
-   * @return if connection is present or no
+   * @return copy of map
    */
-  boolean checkIfConnectionPresent(Connection connection) {
-    return connection2rules.containsKey(connection);
+  Map<Connection, HighlightRule> getConnection2rules() {
+    return Collections.unmodifiableMap(connection2rules);
   }
 
   public void removeConnection(Connection connection) {

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -224,7 +224,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
                 Arrays.asList(meta.getSQLKeywords().split(",")));
         String sqlIdentifier = meta.getIdentifierQuoteString();
         sqlIdentifier = " ".equals(sqlIdentifier)
-            ? DEFAULT_SQL_IDENTIFIER_QUOTE : sqlIdentifier;
+            ? getDefaultSqlIdentifierQuote() : sqlIdentifier;
         HighlightRule rule =
             new HighlightRule(connectionSQLKeyWords, sqlIdentifier);
         connection2rules.put(databaseConnection.connection, rule);
@@ -236,6 +236,10 @@ public class SqlLineHighlighter extends DefaultHighlighter {
       sqlLine.handleException(sqle);
     }
     return null;
+  }
+
+  String getDefaultSqlIdentifierQuote() {
+    return DEFAULT_SQL_IDENTIFIER_QUOTE;
   }
 
   private void handleSqlSyntax(
@@ -261,7 +265,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
         highlightRule == null
             ? null : highlightRule.connectionBasedSqlKeyWordsSet;
     final String sqlIdentifier = highlightRule == null
-        ? DEFAULT_SQL_IDENTIFIER_QUOTE : highlightRule.sqlIdentifierQuote;
+        ? getDefaultSqlIdentifierQuote() : highlightRule.sqlIdentifierQuote;
     for (int pos = start; pos < buffer.length(); pos++) {
       char ch = buffer.charAt(pos);
       if (wordStart > -1) {

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -67,7 +67,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
   public AttributedString highlight(
       LineReader reader, String buffer) {
     boolean skipSyntaxHighlighter =
-        SqlLineOpts.DEFAULT.equals(sqlLine.getOpts().getColorScheme());
+        SqlLineProperty.DEFAULT.equals(sqlLine.getOpts().getColorScheme());
     if (skipSyntaxHighlighter) {
       return super.highlight(reader, buffer);
     }

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -1,0 +1,345 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.impl.DefaultHighlighter;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+import org.jline.utils.WCWidth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.TreeSet;
+
+/**
+ * test.
+ */
+public class SqlLineHighlighter extends DefaultHighlighter {
+  private final SqlLine sqlLine;
+  private Set<String> sqlKeyWords;
+
+  public SqlLineHighlighter(SqlLine sqlLine) {
+    this.sqlLine = sqlLine;
+    try {
+      String keywords =
+          new BufferedReader(
+              new InputStreamReader(
+                  SqlCompleter.class.getResourceAsStream(
+                      "sql-keywords.properties"), StandardCharsets.UTF_8)
+          ).readLine();
+      sqlKeyWords = new TreeSet<>();
+      for (StringTokenizer tok = new StringTokenizer(keywords, ",");
+           tok.hasMoreTokens();) {
+        sqlKeyWords.add(tok.nextToken());
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public AttributedString highlight(LineReader reader, String buffer) {
+    int underlineStart = -1;
+    int underlineEnd = -1;
+    int negativeStart = -1;
+    int negativeEnd = -1;
+    boolean command = false;
+    boolean isSql = false;
+    BitSet sqlKeyWordsBitSet = null;
+    BitSet quoteBitSet = new BitSet(buffer.length());
+    BitSet doubleQuoteBitSet = new BitSet(buffer.length());
+    BitSet commentBitSet = null;
+    BitSet numberBitSet = new BitSet(buffer.length());
+    String trimmed = buffer.trim();
+    boolean isCommandPresent = trimmed.startsWith(SqlLine.COMMAND_PREFIX);
+    if (trimmed.startsWith("!all")
+        || trimmed.startsWith("!call")
+        || trimmed.startsWith("!sql")
+        || !isCommandPresent) {
+      isSql = true;
+    }
+
+    String possibleCommand;
+    if (trimmed.length() > 1 && isCommandPresent) {
+      int end = trimmed.indexOf(' ');
+      possibleCommand = end == -1 ? trimmed.substring(1) : trimmed.substring(1, end);
+      for (CommandHandler ch : sqlLine.getCommandHandlers()) {
+        if (Objects.equals(possibleCommand, ch.getName())
+          || ch.getNames().contains(possibleCommand)) {
+          command = true;
+          break;
+        }
+      }
+    }
+    if (isSql) {
+      int wordStart = -1;
+      int start = 0;
+      if (isCommandPresent) {
+        start = buffer.indexOf(SqlLine.COMMAND_PREFIX) + SqlLine.COMMAND_PREFIX.length();
+        int nextSpace = buffer.indexOf(' ', buffer.indexOf(SqlLine.COMMAND_PREFIX));
+        start = nextSpace == -1 ? buffer.length() : start + nextSpace;
+      }
+
+      for (int pos = start; pos < buffer.length(); pos++) {
+        char ch = buffer.charAt(pos);
+        if (ch == '"') {
+          if (doubleQuoteBitSet == null) {
+            doubleQuoteBitSet = new BitSet(buffer.length());
+          }
+          pos = handleDoubleQuotes(buffer, doubleQuoteBitSet, pos);
+          continue;
+        }
+        if (ch == '\'') {
+          if (quoteBitSet == null) {
+            quoteBitSet = new BitSet(buffer.length());
+          }
+          pos = handleSqlSingleQuotes(buffer, quoteBitSet, pos);
+          continue;
+        }
+        if (pos < buffer.length() - 1) {
+          if (commentBitSet == null) {
+            commentBitSet = new BitSet(buffer.length());
+          }
+          pos = handleComments(buffer, commentBitSet, pos, ch);
+        }
+        if (wordStart == -1
+            && (Character.isLetter(ch)
+             || ch == '@' || ch == '#' || ch == '_')
+            && (pos == 0 || buffer.charAt(pos - 1) != '.')) {
+          wordStart = pos;
+          continue;
+        }
+        if (wordStart == -1 && Character.isDigit(ch)) {
+          pos = handleNumbers(buffer, numberBitSet, pos);
+          continue;
+        }
+        if (wordStart > -1
+            && (pos == buffer.length() - 1
+                || (!Character.isLetterOrDigit(ch)
+                    && ch != '$' && ch != '_' && ch != '@' && ch != '#'))) {
+          String word = !Character.isLetterOrDigit(ch)
+              ? buffer.substring(wordStart, pos)
+              : buffer.substring(wordStart);
+          if (sqlKeyWords.contains(word.toUpperCase(Locale.ROOT))) {
+            if (sqlKeyWordsBitSet == null) {
+              sqlKeyWordsBitSet = new BitSet(buffer.length());
+            }
+            sqlKeyWordsBitSet.set(wordStart, wordStart + word.length());
+          }
+          wordStart = -1;
+        }
+      }
+    } else {
+      int doubleQuoteStart = -1;
+      int quoteStart = -1;
+      for (int pos = 0; pos < buffer.length(); pos++) {
+        char ch = buffer.charAt(pos);
+        if (doubleQuoteStart > -1) {
+          doubleQuoteBitSet.set(pos);
+          if (ch == '"') {
+            doubleQuoteStart = -1;
+          }
+          continue;
+        } else if (quoteStart > -1) {
+          quoteBitSet.set(pos);
+          if (ch == '\'') {
+            quoteStart = -1;
+          }
+          continue;
+        }
+        if (quoteStart == -1 && doubleQuoteStart == -1 && ch == '"') {
+          doubleQuoteBitSet.set(pos);
+          doubleQuoteStart = pos;
+        }
+
+        if (doubleQuoteStart == -1 && quoteStart == -1 && ch == '\'') {
+          quoteBitSet.set(pos);
+          quoteStart = pos;
+        }
+      }
+    }
+    String search = reader.getSearchTerm();
+    if (search != null && search.length() > 0) {
+      underlineStart = buffer.indexOf(search);
+      if (underlineStart >= 0) {
+        underlineEnd = underlineStart + search.length() - 1;
+      }
+    }
+    if (reader.getRegionActive() != LineReader.RegionType.NONE) {
+      negativeStart = reader.getRegionMark();
+      negativeEnd = reader.getBuffer().cursor();
+      if (negativeStart > negativeEnd) {
+        int x = negativeEnd;
+        negativeEnd = negativeStart;
+        negativeStart = x;
+      }
+      if (reader.getRegionActive() == LineReader.RegionType.LINE) {
+        while (negativeStart > 0 && reader.getBuffer().atChar(negativeStart - 1) != '\n') {
+          negativeStart--;
+        }
+        while (negativeEnd < reader.getBuffer().length() - 1
+            && reader.getBuffer().atChar(negativeEnd + 1) != '\n') {
+          negativeEnd++;
+        }
+      }
+    }
+
+    AttributedStringBuilder sb = new AttributedStringBuilder();
+    final int commandStart = buffer.indexOf(SqlLine.COMMAND_PREFIX);
+    final int commandEnd = buffer.indexOf(' ', commandStart);
+    final Application.HightlightConfig highlightConfig = sqlLine.getHighlightConfig();
+    for (int i = 0; i < buffer.length(); i++) {
+      if (isSql) {
+        if (sqlKeyWordsBitSet != null && sqlKeyWordsBitSet.get(i)) {
+          sb.style(highlightConfig.getSqlKeywordStyle());
+        } else if (quoteBitSet != null && quoteBitSet.get(i)) {
+          sb.style(highlightConfig.getQuotedStyle());
+        } else if (doubleQuoteBitSet != null && doubleQuoteBitSet.get(i)) {
+          sb.style(highlightConfig.getDoubleQuotedStyle());
+        } else if (commentBitSet != null && commentBitSet.get(i)) {
+          sb.style(highlightConfig.getCommentedStyle());
+        } else if (numberBitSet != null && numberBitSet.get(i)) {
+          sb.style(highlightConfig.getNumbersStyle());
+        } else if (i > commandEnd
+          && (i < underlineStart || i > underlineEnd)
+          && (i < negativeStart || i > negativeEnd)) {
+          sb.style(highlightConfig.getDefaultStyle());
+        }
+      } else {
+        if (quoteBitSet != null && quoteBitSet.get(i)) {
+          sb.style(highlightConfig.getQuotedStyle());
+        } else if (doubleQuoteBitSet != null && doubleQuoteBitSet.get(i)) {
+          sb.style(highlightConfig.getDoubleQuotedStyle());
+        }
+      }
+
+      if (i == commandStart && command) {
+        sb.style(highlightConfig.getCommandStyle());
+      }
+      if (i >= underlineStart && i <= underlineEnd) {
+        sb.style(sb.style().underline());
+      }
+      if (i >= negativeStart && i <= negativeEnd) {
+        sb.style(sb.style().inverse());
+      }
+      char c = buffer.charAt(i);
+      if (c == '\t' || c == '\n') {
+        sb.append(c);
+      } else if (c < 32) {
+        sb.style(AttributedStyle::inverseNeg)
+            .append('^')
+            .append((char) (c + '@'))
+            .style(AttributedStyle::inverseNeg);
+      } else {
+        int w = WCWidth.wcwidth(c);
+        if (w > 0) {
+          sb.append(c);
+        }
+      }
+      if (i == underlineEnd) {
+        sb.style(sb.style().underlineOff());
+      }
+      if (i == negativeEnd) {
+        sb.style(sb.style().inverseOff());
+      }
+      if (i == commandEnd) {
+        sb.style(highlightConfig.getDefaultStyle());
+      }
+
+    }
+    return sb.toAttributedString();
+  }
+
+  protected int handleDoubleQuotes(String buffer, BitSet doubleQuoteBitSet, int pos) {
+    int end = buffer.indexOf('"', pos + 1);
+    end = end == -1 ? buffer.length() - 1 : end;
+    doubleQuoteBitSet.set(pos, end + 1);
+    pos = end;
+    return pos;
+  }
+
+  protected int handleNumbers(String buffer, BitSet numberBitSet, int pos) {
+    int end = pos + 1;
+    while (end < buffer.length() && Character.isDigit(buffer.charAt(end))) {
+      end++;
+    }
+    if (end == buffer.length()) {
+      if (Character.isDigit(buffer.charAt(buffer.length() - 1))) {
+        numberBitSet.set(pos, end + 1);
+      }
+    } else if (Character.isWhitespace(buffer.charAt(end))
+      || buffer.charAt(end) == ';'
+      || buffer.charAt(end) == ','
+      || buffer.charAt(end) == '='
+      || buffer.charAt(end) == '<'
+      || buffer.charAt(end) == '>'
+      || buffer.charAt(end) == '-'
+      || buffer.charAt(end) == '+'
+      || buffer.charAt(end) == '/'
+      || buffer.charAt(end) == ')'
+      || buffer.charAt(end) == '%'
+      || buffer.charAt(end) == '*') {
+      numberBitSet.set(pos, end);
+    }
+    pos = end;
+    return pos;
+  }
+
+  private int handleComments(String buffer, BitSet commentBitSet, int pos, char ch) {
+    if (ch == '-' && buffer.charAt(pos + 1) == '-') {
+      int end = buffer.indexOf('\n', pos);
+      end = end == -1 ? buffer.length() : end;
+      commentBitSet.set(pos, end + 1);
+      pos = end;
+    } else if (ch == '/' && buffer.charAt(pos + 1) == '*') {
+      int end = buffer.indexOf("*/", pos);
+      end = end == -1 ? buffer.length() : end + 1;
+      commentBitSet.set(pos, end + 1);
+      pos = end;
+    }
+    return pos;
+  }
+
+  protected int handleSqlSingleQuotes(String buffer, BitSet quoteBitSet, int pos) {
+    int end;
+    int quoteCounter = 1;
+    boolean quotationEnded = false;
+    do {
+      end = buffer.indexOf('\'', pos + 1);
+      if (end > -1) {
+        quoteCounter++;
+      }
+      if (end == -1 || end == buffer.length() - 1) {
+        quoteBitSet.set(pos, buffer.length());
+        quotationEnded = true;
+      } else if (buffer.charAt(end + 1) != '\'' && quoteCounter % 2 == 0) {
+        quotationEnded = true;
+      }
+      end = end == -1 ? buffer.length() : end;
+      quoteBitSet.set(pos, end + 1);
+      pos = end;
+    } while (!quotationEnded && end < buffer.length());
+    return pos;
+  }
+
+}
+
+// End SqlLineHighlighter.java

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -32,6 +32,7 @@ import sqlline.SqlLineProperty.Type;
 import static sqlline.BuiltInProperty.AUTO_COMMIT;
 import static sqlline.BuiltInProperty.AUTO_SAVE;
 import static sqlline.BuiltInProperty.COLOR;
+import static sqlline.BuiltInProperty.COLOR_SCHEME;
 import static sqlline.BuiltInProperty.CSV_DELIMITER;
 import static sqlline.BuiltInProperty.CSV_QUOTE_CHARACTER;
 import static sqlline.BuiltInProperty.DATE_FORMAT;
@@ -468,6 +469,21 @@ public class SqlLineOpts implements Completer {
           .setVariable(LineReader.HISTORY_FILE, get(HISTORY_FILE));
       new DefaultHistory().attach(sqlLine.getLineReader());
     }
+  }
+
+  public void setColorScheme(String colorScheme) {
+    if (DEFAULT.equals(colorScheme)
+        || HighlightStyle.NAME2HIGHLIGHT_STYLE.containsKey(colorScheme)) {
+      propertiesMap.put(COLOR_SCHEME, colorScheme);
+      return;
+    }
+    throw new IllegalArgumentException(
+        "Possible values are: "
+            + new TreeSet<>(HighlightStyle.NAME2HIGHLIGHT_STYLE.keySet()));
+  }
+
+  public String getColorScheme() {
+    return get(COLOR_SCHEME);
   }
 
   public boolean getColor() {

--- a/src/main/java/sqlline/SqlLineParser.java
+++ b/src/main/java/sqlline/SqlLineParser.java
@@ -82,6 +82,8 @@ public class SqlLineParser extends DefaultParser {
 
   public SqlLineParser(final SqlLine sqlLine) {
     this.sqlLine = sqlLine;
+    eofOnUnclosedQuote(true);
+    eofOnEscapedNewLine(true);
   }
 
   public ParsedLine parse(final String line, final int cursor,

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -70,6 +70,8 @@ variables:\
 \nautoCommit      true/false Enable/disable automatic transaction commit\
 \nautoSave        true/false Automatically save preferences\
 \ncolor           true/false Control whether color is used for display\
+\ncolorScheme     chester/dark/dracula/light/ozbsidian/solarized/vs2010\
+\n                           Syntax highlight schema\
 \ncsvDelimiter    String     Delimiter in csv outputFormat\
 \ncsvQuoteCharacter char     Quote character in csv outputFormat\
 \ndateFormat      pattern    Format dates using SimpleDateFormat pattern\
@@ -220,6 +222,8 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  -log <file>                     file to write output\n \
 \  -ac <class name>                application configuration class name\n \
 \  --color=[true/false]            control whether color is used for display\n \
+\  --colorScheme=[chester/dark/dracula/light/ozbsidian/solarized/vs2010]\
+\                                  Syntax highlight schema\n \
 \  --csvDelimiter=[delimiter]      Delimiter in csv outputFormat\n \
 \  --csvQuoteCharacter=[char]      Quote character in csv outputFormat\n \
 \  --escapeOutput=[true/false]     escape control symbols in output\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -100,6 +100,7 @@ Parameter Reference
 autocommit
 autosave
 color
+colorScheme
 csvDelimiter
 csvQuoteCharacter
 dateformat
@@ -227,6 +228,7 @@ Parameter Reference
 autocommit
 autosave
 color
+colorScheme
 csvDelimiter
 csvQuoteCharacter
 dateformat
@@ -1095,6 +1097,8 @@ Variable        Value      Description
 autoCommit      true/false Enable/disable automatic transaction commit
 autoSave        true/false Automatically save preferences
 color           true/false Control whether color is used for display
+colorScheme     chester/dark/dracula/light/ozbsidian/solarized/vs2010
+                           Syntax highlight schema
 csvDelimiter    String     Delimiter in csv outputFormat
 csvQuoteCharacter char     Quote character in csv outputFormat
 dateFormat      pattern    Format dates using SimpleDateFormat pattern
@@ -2021,6 +2025,7 @@ Parameter Reference
 autocommit
 autosave
 color
+colorScheme
 csvDelimiter
 csvQuoteCharacter
 dateformat
@@ -2050,15 +2055,19 @@ trimscripts
 verbose
 autocommit
 
-If true, then new connections will have autocommit set, otherwise, transactions will need to be explicitely committed or rolled back. Defaults to true. To change the autocommit status for a connection that is already open and active, use the autocommit command instead.
+If true, then new connections will have autocommit set, otherwise, transactions will need to be explicitly committed or rolled back. Defaults to true. To change the autocommit status for a connection that is already open and active, use the autocommit command instead.
 
 autosave
 
-When set to true, any changes to preferences using the set command will cause the preferences to be saved. Otherwise, preferences will need to be explicitely saved using the save command. Defaults to false.
+When set to true, any changes to preferences using the set command will cause the preferences to be saved. Otherwise, preferences will need to be explicitly saved using the save command. Defaults to false.
 
 color
 
 If true, then output to the terminal will use color for a more pleasing visual experience. Requires that the terminal support ANSI control codes (most do). Defaults to false.
+
+colorScheme
+
+If chester/dark/dracula/light/ozbsidian/solarized/vs2010, then this scheme will be used for command/sql syntax highlighting. If default then there is no syntax highlighting.
 
 csvDelimiter
 

--- a/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
@@ -34,7 +34,7 @@ public class SqlLineHighlighterLowLevelTest {
 
   @Before
   public void setUp() throws Exception {
-    defaultSqlline = getSqlLine(SqlLineOpts.DEFAULT);
+    defaultSqlline = getSqlLine(SqlLineProperty.DEFAULT);
     defaultHighlighter = new SqlLineHighlighter(defaultSqlline);
   }
 

--- a/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
@@ -81,7 +81,8 @@ public class SqlLineHighlighterLowLevelTest {
    * {@link SqlLineHighlighterTest#testSqlIdentifierQuotes()}}
    * <p>
    * This is a low level test of
-   * {@link SqlLineHighlighter#handleSqlSingleQuotes(String, BitSet, int)}.
+   * {@link SqlLineHighlighter
+   * #handleSqlIdentifierQuotes(String, String, BitSet, int)}.
    */
   @Test
   public void testLowLevelHandleSqlIdentifierQuotes() {

--- a/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
@@ -1,0 +1,279 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for auxiliary methods in {@link SqlLineHighlighter}.
+ */
+public class SqlLineHighlighterLowLevelTest {
+  private SqlLine defaultSqlline = null;
+  private SqlLineHighlighter defaultHighlighter = null;
+
+  @Before
+  public void setUp() throws Exception {
+    defaultSqlline = getSqlLine(SqlLineOpts.DEFAULT);
+    defaultHighlighter = new SqlLineHighlighter(defaultSqlline);
+  }
+
+  @After
+  public void tearDown() {
+    defaultSqlline = null;
+    defaultHighlighter = null;
+  }
+
+  /**
+   * WARNING: Change it only if you know what you are doing.
+   * Otherwise put your test into
+   * {@link SqlLineHighlighterTest#testSingleQuotedStrings()}
+   * <p>
+   * This is a low level test of
+   * {@link SqlLineHighlighter#handleSqlSingleQuotes(String, BitSet, int)}.
+   */
+  @Test
+  public void testLowLevelHandleSqlSingleQuotes() {
+    String[] linesRequiredToBeQuoted = {
+        "'from'",
+        "''''",
+        "''",
+        "'",
+        "'test '' \n''select'",
+        "'/* \n'",
+        "'-- \n--'",
+        "'\"'"
+    };
+
+    for (String line : linesRequiredToBeQuoted) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.singleQuotes.set(0, line.length());
+      BitSet actual = new BitSet(line.length());
+      defaultHighlighter.handleSqlSingleQuotes(line, actual, 0);
+      assertEquals("Line [" + line + "]", expectedStyle.singleQuotes, actual);
+    }
+  }
+
+  /**
+   * WARNING: Change it only if you know what you are doing.
+   * Otherwise put your test into
+   * {@link SqlLineHighlighterTest#testSqlIdentifierQuotes()}}
+   * <p>
+   * This is a low level test of
+   * {@link SqlLineHighlighter#handleSqlSingleQuotes(String, BitSet, int)}.
+   */
+  @Test
+  public void testLowLevelHandleSqlIdentifierQuotes() {
+    String[] linesRequiredToBeDoubleQuoted = {
+        "\"",
+        "\"\"",
+        "\"from\"",
+        "\"''\"",
+        "\"test '' \n''select\"",
+        "\"/* \\\"kjh\"",
+        "\"/* \\\" \\\" \\\"  \"",
+        "\"--   \"",
+        "\"\n  \n\""
+    };
+
+    String[] linesRequiredToBeBackTickQuoted = {
+        "`",
+        "``",
+        "`from`",
+        "`''`",
+        "`test \\` \n\\`select`",
+        "`/* \\`kjh`",
+        "`/* \\` \\` \\`  `",
+        "`--   `",
+        "`\n  \n`"
+    };
+
+    for (String line : linesRequiredToBeDoubleQuoted) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.sqlIdentifierQuotes.set(0, line.length());
+      BitSet actual = new BitSet(line.length());
+      defaultHighlighter.handleSqlIdentifierQuotes(line, "\"", actual, 0);
+      assertEquals(
+          "Line [" + line + "]", expectedStyle.sqlIdentifierQuotes, actual);
+    }
+
+    for (String line : linesRequiredToBeBackTickQuoted) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.sqlIdentifierQuotes.set(0, line.length());
+      BitSet actual = new BitSet(line.length());
+      defaultHighlighter.handleSqlIdentifierQuotes(line, "`", actual, 0);
+      assertEquals(
+          "Line [" + line + "]", expectedStyle.sqlIdentifierQuotes, actual);
+    }
+  }
+
+  /**
+   * WARNING: Change it only if you know what you are doing.
+   * Otherwise put your test into
+   * {@link SqlLineHighlighterTest#testCommentedStrings()}
+   * <p>
+   * This is a low level test of
+   * {@link SqlLineHighlighter#handleComments(String, BitSet, int)}.
+   */
+  @Test
+  public void testLowLevelHandleComments() {
+    String[] linesRequiredToBeComments = {
+        "-- 'asdasd'asd",
+        "--select",
+        "/* \"''\"",
+        "/*",
+        "--",
+        "/* kh\n'asd'ad*/",
+        "/*\"-- \"values*/"
+    };
+
+    for (String line : linesRequiredToBeComments) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.comments.set(0, line.length());
+      BitSet actual = new BitSet(line.length());
+      defaultHighlighter.handleComments(line, actual, 0);
+      assertEquals("Line [" + line + "]", expectedStyle.comments, actual);
+    }
+  }
+
+  /**
+   * WARNING: Change it only if you know what you are doing.
+   * Otherwise put your test into
+   * {@link SqlLineHighlighterTest#testNumberStrings()}.
+   * <p>
+   * This is a low level test of
+   * {@link SqlLineHighlighter#handleNumbers(String, BitSet, int)}.
+   */
+  @Test
+  public void testLowLevelHandleNumbers() {
+    String[] linesRequiredToBeNumbers = {
+        "123456789",
+        "0123",
+        "1"
+    };
+
+    for (String line : linesRequiredToBeNumbers) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.numbers.set(0, line.length());
+      BitSet actual = new BitSet(line.length());
+      defaultHighlighter.handleNumbers(line, actual, 0);
+      assertEquals("Line [" + line + "]", expectedStyle.numbers, actual);
+    }
+  }
+
+  /**
+   * WARNING: Change it only if you know what you are doing.
+   * Otherwise put your test into {@link SqlLineHighlighterTest#testCommands()}
+   * or {@link SqlLineHighlighterTest#testComplexStrings()}
+   * <p>
+   * This is a low level test of
+   * {@link SqlLineHighlighter#handleQuotesInCommands(String, BitSet, BitSet)}.
+   */
+  @Test
+  public void testLowLevelQuotesInCommands() {
+    String[] commandsWithSingleQuotedInput = {
+        "!set csvdelimiter '\"'",
+        "!set csvdelimiter '\"\"'",
+        "!set csvdelimiter '\"\"\"'",
+    };
+    String[] commandsWithDoubleQuotedInput = {
+        "!set csvdelimiter \"'\"",
+        "!set csvdelimiter \"''\"",
+        "!set csvdelimiter \"'''\"",
+    };
+
+    for (String line : commandsWithSingleQuotedInput) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.singleQuotes
+          .set(line.indexOf("'"), line.length());
+      BitSet actualSingleQuotes = new BitSet(line.length());
+      BitSet actualDoubleQuotes = new BitSet(line.length());
+      defaultHighlighter
+          .handleQuotesInCommands(line, actualSingleQuotes, actualDoubleQuotes);
+      assertEquals("Line [" + line + "]",
+          expectedStyle.singleQuotes, actualSingleQuotes);
+      assertEquals("Line [" + line + "]",
+          expectedStyle.sqlIdentifierQuotes, actualDoubleQuotes);
+    }
+
+    for (String line : commandsWithDoubleQuotedInput) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.sqlIdentifierQuotes
+          .set(line.indexOf("\""), line.length());
+      BitSet actualSingleQuotes = new BitSet(line.length());
+      BitSet actualDoubleQuotes = new BitSet(line.length());
+      defaultHighlighter
+          .handleQuotesInCommands(line, actualSingleQuotes, actualDoubleQuotes);
+      assertEquals("Line [" + line + "]",
+          expectedStyle.singleQuotes, actualSingleQuotes);
+      assertEquals("Line [" + line + "]",
+          expectedStyle.sqlIdentifierQuotes, actualDoubleQuotes);
+    }
+  }
+
+  static SqlLine getSqlLine(String colorScheme) throws IOException {
+    SqlLine sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream sqllineOutputStream =
+        new PrintStream(os, false, StandardCharsets.UTF_8.name());
+    sqlLine.setOutputStream(sqllineOutputStream);
+    sqlLine.setErrorStream(sqllineOutputStream);
+    final InputStream is = new ByteArrayInputStream(new byte[0]);
+    sqlLine.begin(new String[]{"-e", "!set maxwidth 80"}, is, false);
+    sqlLine.getOpts().setColorScheme(colorScheme);
+    return sqlLine;
+  }
+
+  /**
+   * Class to test highlight styles.
+   */
+  static class ExpectedHighlightStyle {
+    final BitSet commands;
+    final BitSet keywords;
+    final BitSet singleQuotes;
+    final BitSet sqlIdentifierQuotes;
+    final BitSet defaults;
+    final BitSet numbers;
+    final BitSet comments;
+
+    ExpectedHighlightStyle(int length) {
+      commands = new BitSet(length);
+      keywords = new BitSet(length);
+      singleQuotes = new BitSet(length);
+      sqlIdentifierQuotes = new BitSet(length);
+      numbers = new BitSet(length);
+      comments = new BitSet(length);
+      defaults = new BitSet(length);
+    }
+  }
+
+}
+
+// End SqlLineHighlighterLowLevelTest.java

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -453,10 +453,17 @@ public class SqlLineHighlighterTest {
   }
 
   @Test
-  public void testSqlKeywordsFromDatabase() {
+  public void testH2SqlKeywordsFromDatabase() {
+    // The list is taken from H2 1.4.197 getSQLKeywords output
     String[] linesRequiredToBeNumbers = {
-        "minus",
-        "today",
+        "LIMIT",
+        "MINUS",
+        "OFFSET",
+        "ROWNUM",
+        "SYSDATE",
+        "SYSTIME",
+        "SYSTIMESTAMP",
+        "TODAY",
     };
 
     for (String line : linesRequiredToBeNumbers) {

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -20,97 +20,323 @@ import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 
 import org.jline.utils.AttributedString;
-import org.jline.utils.AttributedStyle;
-import org.junit.Test;
 
 import junit.framework.TestCase;
+
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Tests for sql and command syntax highlighting in sqlline.
  */
 public class SqlLineHighlighterTest extends TestCase {
-  @Test
-  public void testHandleNumbers() throws IOException {
-    SqlLineHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
-    String inputString = "select 1+1, 2*2, 3-1, 1/1 from dual where 0=0";
-    BitSet expectedBitSet = new BitSet(inputString.length());
-    expectedBitSet.set(7);
-    expectedBitSet.set(9);
-    expectedBitSet.set(12);
-    expectedBitSet.set(14);
-    expectedBitSet.set(17);
-    expectedBitSet.set(19);
-    expectedBitSet.set(22);
-    expectedBitSet.set(24);
-    expectedBitSet.set(42);
-    expectedBitSet.set(44);
 
-    BitSet numberBitSet = new BitSet(inputString.length());
-    for (int i = 0; i < inputString.length(); i++) {
-      if (Character.isDigit(inputString.charAt(i))) {
-        i = highlighter.handleNumbers(inputString, numberBitSet, i);
-      }
-    }
-    assertEquals(expectedBitSet, numberBitSet);
+  private SqlLine sqlLine = null;
+  private SqlLineHighlighter highlighter;
+
+  public void setUp() throws Exception {
+    sqlLine = getSqlLine();
+    highlighter = new SqlLineHighlighter(sqlLine);
   }
 
-  @Test
-  public void testHandleKeyWords() throws IOException {
-    SqlLineHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
-    String inputString = "select 1+1, 2*2, 3-1, 1/1 from dual where 0=0";
-    BitSet expectedBitSet = new BitSet(inputString.length());
-    expectedBitSet.set(7);
-    expectedBitSet.set(9);
-    expectedBitSet.set(12);
-    expectedBitSet.set(14);
-    expectedBitSet.set(17);
-    expectedBitSet.set(19);
-    expectedBitSet.set(22);
-    expectedBitSet.set(24);
-    expectedBitSet.set(42);
-    expectedBitSet.set(44);
-
-    BitSet numberBitSet = new BitSet(inputString.length());
-    for (int i = 0; i < inputString.length(); i++) {
-      if (Character.isDigit(inputString.charAt(i))) {
-        i = highlighter.handleNumbers(inputString, numberBitSet, i);
-      }
-    }
-    assertEquals(expectedBitSet, numberBitSet);
+  public void tearDown() {
+    sqlLine = null;
+    highlighter = null;
   }
 
-  @Test
-  public void testBoldStrings() throws IOException {
-    SqlLine sqlLine = new SqlLine();
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    PrintStream sqllineOutputStream =
-        new PrintStream(os, false, StandardCharsets.UTF_8.name());
-    sqlLine.setOutputStream(sqllineOutputStream);
-    sqlLine.setErrorStream(sqllineOutputStream);
-    final InputStream is = new ByteArrayInputStream(new byte[0]);
-    sqlLine.begin(new String[]{"-e", "!set maxwidth 80"}, is, false);
-    SqlLineHighlighter sqlLineHighlighter = new SqlLineHighlighter(sqlLine);
-    String[] stringsRequiredToBeBold = new String[] {
+  public void testCommands() {
+    String[] linesRequiredToBeCommands = {
         "!set",
         "!commandhandler",
+        "!quit",
+        "!isolation",
+        "!dbinfo",
+        "!help",
+        "!connect"
+    };
+
+    for (String line : linesRequiredToBeCommands) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.commands.set(0, line.length());
+      checkLine(sqlLine, line, expectedStyle, highlighter);
+    }
+  }
+
+  public void testKeywords() {
+    String[] linesRequiredToBeKeywords = {
+        "from",
+        "outer",
         "select",
         "values",
         "where",
         "join",
-        "!connect"
+        "cross"
     };
-    for (String str: stringsRequiredToBeBold) {
-      AttributedString stringSelect =
-          sqlLineHighlighter.highlight(sqlLine.getLineReader(), str);
-      for (int i = 0; i < str.length(); i++) {
-        assertTrue("String '" + str + "' should be in bold",
-            isBold(stringSelect.styleAt(i)));
+
+    for (String line : linesRequiredToBeKeywords) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.keywords.set(0, line.length());
+      checkLine(sqlLine, line, expectedStyle, highlighter);
+    }
+  }
+
+  public void testSingleQuotedStrings() {
+    String[] linesRequiredToBeSingleQuoted = {
+        "'from'",
+        "''''",
+        "''",
+        "'",
+        "'test '' \n''select'",
+        "'/* \n'",
+        "'-- \n--'",
+        "'\"'"
+    };
+
+    for (String line : linesRequiredToBeSingleQuoted) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.singleQuotes.set(0, line.length());
+      checkLine(sqlLine, line, expectedStyle, highlighter);
+    }
+  }
+
+  public void testDoubleQuotedStrings() {
+    String[] linesRequiredToBeDoubleQuoted = {
+        "\"",
+        "\"\"",
+        "\"from\"",
+        "\"''\"",
+        "\"test '' \n''select\"",
+        "\"/* \"",
+        "\"/*   \"",
+        "\"--   \"",
+        "\"\n  \n\""
+    };
+
+    for (String line : linesRequiredToBeDoubleQuoted) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.doubleQuotes.set(0, line.length());
+      checkLine(sqlLine, line, expectedStyle, highlighter);
+    }
+  }
+
+  public void testCommentedStrings() {
+    String[] linesRequiredToBeComments = {
+        "-- 'asdasd'asd",
+        "--select",
+        "/* \"''\"",
+        "/*",
+        "--",
+        "/* kh\n'asd'ad*/",
+        "/*\"-- \"values*/"
+    };
+
+    for (String line : linesRequiredToBeComments) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.comments.set(0, line.length());
+      checkLine(sqlLine, line, expectedStyle, highlighter);
+    }
+  }
+
+  public void testNumberStrings() {
+    String[] linesRequiredToBeNumbers = {
+        "123456789",
+        "0123",
+        "1"
+    };
+
+    for (String line : linesRequiredToBeNumbers) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.numbers.set(0, line.length());
+      checkLine(sqlLine, line, expectedStyle, highlighter);
+    }
+  }
+
+  public void testComplexStrings() throws IOException {
+    final SqlLine sqlLine = getSqlLine();
+    final SqlLineHighlighter highlighter = new SqlLineHighlighter(sqlLine);
+
+    // command with argument
+    String line = "!set version";
+    ExpectedHighlightStyle expectedStyle =
+        new ExpectedHighlightStyle(line.length());
+    expectedStyle.commands.set(0, "!set".length());
+    expectedStyle.defaults.set("!set".length(), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    // command with quoted argument
+    line = "!set csvdelimiter '\"'";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.commands.set(0, "!set".length());
+    expectedStyle.defaults.set("!set".length(), line.indexOf("'\"'"));
+    expectedStyle.singleQuotes.set(line.indexOf("'\"'"), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    // command with double quoted argument
+    line = "!set csvdelimiter \"'\"";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.commands.set(0, "!set".length());
+    expectedStyle.defaults.set("!set".length(), line.indexOf("\"'\""));
+    expectedStyle.doubleQuotes.set(line.indexOf("\"'\""), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    // command with double quoted argument and \n
+    line = "!set csvdelimiter \"'\n\"";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.commands.set(0, "!set".length());
+    expectedStyle.defaults.set("!set".length(), line.indexOf("\"'\n\""));
+    expectedStyle.doubleQuotes.set(line.indexOf("\"'\n\""), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    line = "select '1'";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.keywords.set(0, "select".length());
+    expectedStyle.defaults.set("select".length(), line.indexOf(' ') + 1);
+    expectedStyle.singleQuotes.set(line.indexOf(' ') + 1, line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    //no spaces
+    line = "select'1'as\"21\"";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.keywords.set(0, "select".length());
+    expectedStyle.defaults.set("select".length(), line.indexOf('\''));
+    expectedStyle.singleQuotes.set(line.indexOf('\''), line.indexOf("as"));
+    expectedStyle.keywords.set(line.indexOf("as"), line.indexOf("\"21\""));
+    expectedStyle.doubleQuotes.set(line.indexOf("\"21\""), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    //not valid sql with comments /**/ and not ended quoted line
+    line = "select/*123'1'*/'as\"21\"";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.keywords.set(0, "select".length());
+    expectedStyle.comments
+        .set(line.indexOf("/*123'1'*/"), line.indexOf("'as\"21\""));
+    expectedStyle.singleQuotes.set(line.indexOf("'as\"21\""), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    //not valid sql with not ended multiline comment
+    line = "select /*\n * / \n 123 as \"q\" \nfrom dual\n where\n 1 = 1";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.keywords.set(0, "select".length());
+    expectedStyle.defaults.set("select".length());
+    expectedStyle.comments
+        .set(line.indexOf("/*\n"), line.length());
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+
+    //multiline sql with comments
+    line = "select/*multiline\ncomment\n*/0 as \"0\","
+        + "'qwe'\n--comment\nas\"21\"from t\n where 1=1";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.keywords.set(0, "select".length());
+    expectedStyle.comments.set("select".length(), line.indexOf("0 as"));
+    expectedStyle.numbers.set(line.indexOf("0 as"));
+    expectedStyle.defaults.set(line.indexOf(" as \"0\","));
+    expectedStyle.keywords
+        .set(line.indexOf("as \"0\","), line.indexOf(" \"0\","));
+    expectedStyle.defaults.set(line.indexOf(" \"0\","));
+    expectedStyle.doubleQuotes
+        .set(line.indexOf("\"0\","), line.indexOf(",'qwe"));
+    expectedStyle.defaults.set(line.indexOf(",'qwe"));
+    expectedStyle.singleQuotes
+        .set(line.indexOf("'qwe'"), line.indexOf("\n--comment\nas"));
+    expectedStyle.defaults.set(line.indexOf("\n--comment"));
+    expectedStyle.comments
+        .set(line.indexOf("--comment\n"), line.indexOf("as\"21\""));
+    expectedStyle.keywords
+        .set(line.indexOf("as\"21\""), line.indexOf("\"21\"from"));
+    expectedStyle.doubleQuotes
+        .set(line.indexOf("\"21\""), line.indexOf("from"));
+    expectedStyle.keywords.set(line.indexOf("from"), line.indexOf(" t\n"));
+    expectedStyle.defaults.set(line.indexOf(" t\n"), line.indexOf("where"));
+    expectedStyle.keywords.set(line.indexOf("where"), line.indexOf(" 1=1"));
+    expectedStyle.defaults.set(line.indexOf(" 1=1"));
+    expectedStyle.numbers.set(line.indexOf("1=1"));
+    expectedStyle.defaults.set(line.indexOf("=1"));
+    expectedStyle.numbers.set(line.indexOf("=1") + 1);
+    checkLine(sqlLine, line, expectedStyle, highlighter);
+  }
+
+  private void checkLine(
+      SqlLine sqlLine,
+      String line,
+      ExpectedHighlightStyle expectedHighlightStyle,
+      SqlLineHighlighter highlighter) {
+    AttributedString attributedString =
+        highlighter.highlight(sqlLine.getLineReader(), line);
+    Application.HighlightConfig highlightConfig = sqlLine.getHighlightConfig();
+    int commandsStyle = highlightConfig.getCommandStyle().getStyle();
+    int keyWordStyle = highlightConfig.getSqlKeywordStyle().getStyle();
+    int singleQuoteStyle = highlightConfig.getQuotedStyle().getStyle();
+    int doubleQuoteStyle = highlightConfig.getDoubleQuotedStyle().getStyle();
+    int commentsStyle = highlightConfig.getCommentedStyle().getStyle();
+    int numbersStyle = highlightConfig.getNumbersStyle().getStyle();
+    int defaultStyle = highlightConfig.getDefaultStyle().getStyle();
+
+    for (int i = 0; i < line.length(); i++) {
+      checkSymbolStyle(line, i, expectedHighlightStyle.commands,
+          attributedString, commandsStyle, "command");
+
+      checkSymbolStyle(line, i, expectedHighlightStyle.keywords,
+          attributedString, keyWordStyle, "key word");
+
+      checkSymbolStyle(line, i, expectedHighlightStyle.singleQuotes,
+          attributedString, singleQuoteStyle, "single quote");
+
+      checkSymbolStyle(line, i, expectedHighlightStyle.doubleQuotes,
+          attributedString, doubleQuoteStyle, "double quote");
+
+      checkSymbolStyle(line, i, expectedHighlightStyle.numbers,
+          attributedString, numbersStyle, "number");
+
+      checkSymbolStyle(line, i, expectedHighlightStyle.comments,
+          attributedString, commentsStyle, "comment");
+
+      checkSymbolStyle(line, i, expectedHighlightStyle.defaults,
+          attributedString, defaultStyle, "default");
+    }
+  }
+
+  private void checkSymbolStyle(
+      String line,
+      int i,
+      BitSet styleBitSet,
+      AttributedString highlightedLine,
+      int style,
+      String styleName) {
+    if (styleBitSet.get(i)) {
+      assertEquals(getFailedStyleMessage(line, i, styleName),
+          i == 0 ? style + 32 : style,
+          highlightedLine.styleAt(i).getStyle());
+    } else {
+      if (!Character.isWhitespace(line.charAt(i))) {
+        assertNotEquals(getNegativeFailedStyleMessage(line, i, styleName),
+            i == 0 ? style + 32 : style,
+            highlightedLine.styleAt(i).getStyle());
       }
     }
   }
 
-  @Test
-  public void testNotBoldStrings() throws IOException {
+  private String getFailedStyleMessage(String line, int i, String style) {
+    return getFailedStyleMessage(line, i, style, true);
+  }
+
+  private String getNegativeFailedStyleMessage(
+      String line, int i, String style) {
+    return getFailedStyleMessage(line, i, style, false);
+  }
+
+  private String getFailedStyleMessage(
+      String line, int i, String style, boolean positive) {
+    return "String '" + line + "', symbol '" + line.charAt(i)
+        + "' at (" + i + ") " + "position should "
+        + (positive ? "" : "not ") + "be " + style + " style";
+  }
+
+  private SqlLine getSqlLine() throws IOException {
     SqlLine sqlLine = new SqlLine();
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     PrintStream sqllineOutputStream =
@@ -119,27 +345,30 @@ public class SqlLineHighlighterTest extends TestCase {
     sqlLine.setErrorStream(sqllineOutputStream);
     final InputStream is = new ByteArrayInputStream(new byte[0]);
     sqlLine.begin(new String[]{"-e", "!set maxwidth 80"}, is, false);
-    SqlLineHighlighter sqlLineHighlighter = new SqlLineHighlighter(sqlLine);
-    String[] stringsRequiredToBeBold = new String[] {
-        "!st",
-        "!ohandler",
-        "/* select */",
-        "--values",
-        "'where'",
-        "\"join\""
-    };
-    for (String str: stringsRequiredToBeBold) {
-      AttributedString stringSelect =
-          sqlLineHighlighter.highlight(sqlLine.getLineReader(), str);
-      for (int i = 0; i < str.length(); i++) {
-        assertFalse("String '" + str + "' should be not in bold",
-            isBold(stringSelect.styleAt(i)));
-      }
-    }
+    return sqlLine;
   }
 
-  private boolean isBold(AttributedStyle style) {
-    return style.getMask() % 2 != 0 && style.getStyle() % 2 != 0;
+  /**
+   *  Class to test highlight styles.
+   */
+  private class ExpectedHighlightStyle {
+    private final BitSet commands;
+    private final BitSet keywords;
+    private final BitSet singleQuotes;
+    private final BitSet doubleQuotes;
+    private final BitSet defaults;
+    private final BitSet numbers;
+    private final BitSet comments;
+
+    ExpectedHighlightStyle(int length) {
+      commands = new BitSet(length);
+      keywords = new BitSet(length);
+      singleQuotes = new BitSet(length);
+      doubleQuotes = new BitSet(length);
+      numbers = new BitSet(length);
+      comments = new BitSet(length);
+      defaults = new BitSet(length);
+    }
   }
 }
 

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -50,9 +50,9 @@ public class SqlLineHighlighterTest {
   @Before
   public void setUp() throws Exception {
     sqlLine2HighLighter = new HashMap<>();
-    SqlLine defaultSqlline = getSqlLine(SqlLineOpts.DEFAULT);
-    SqlLine darkSqlLine = getSqlLine(SqlLineOpts.DARK_SCHEME);
-    SqlLine lightSqlLine = getSqlLine(SqlLineOpts.LIGHT_SCHEME);
+    SqlLine defaultSqlline = getSqlLine(SqlLineProperty.DEFAULT);
+    SqlLine darkSqlLine = getSqlLine("dark");
+    SqlLine lightSqlLine = getSqlLine("light");
     sqlLine2HighLighter
         .put(defaultSqlline, new SqlLineHighlighter(defaultSqlline));
     sqlLine2HighLighter.put(darkSqlLine, new SqlLineHighlighter(darkSqlLine));
@@ -363,7 +363,7 @@ public class SqlLineHighlighterTest {
 
       // in case of default there is no SQLKeyWords
       // or sqlIdentifierQuote retrieval and as a result no connection usage
-      if (SqlLineOpts.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
+      if (SqlLineProperty.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
         assertTrue(
             sqlLineHighlighter.getConnection2rules().isEmpty());
       } else {
@@ -446,7 +446,7 @@ public class SqlLineHighlighterTest {
 
       // in case of default there is no SQLKeyWords
       // or sqlIdentifierQuote retrieval and as a result no connection usage
-      if (SqlLineOpts.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
+      if (SqlLineProperty.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
         assertTrue(
             sqlLineHighlighter.getConnection2rules().isEmpty());
       } else {
@@ -532,7 +532,7 @@ public class SqlLineHighlighterTest {
       ExpectedHighlightStyle expectedHighlightStyle,
       SqlLine sqlLine,
       SqlLineHighlighter sqlLineHighlighter) {
-    if (SqlLineOpts.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
+    if (SqlLineProperty.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
       checkDefaultLine(sqlLine, line, sqlLineHighlighter);
     } else {
       checkHighlightedLine(sqlLine,

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -20,30 +20,45 @@ import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 
 import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**
  * Tests for sql and command syntax highlighting in sqlline.
  */
-public class SqlLineHighlighterTest extends TestCase {
+public class SqlLineHighlighterTest {
 
-  private SqlLine sqlLine = null;
-  private SqlLineHighlighter highlighter;
+  private SqlLine darkSqlLine = null;
+  private SqlLine defaultSqlline = null;
+  private SqlLine lightSqlLine = null;
+  private SqlLineHighlighter darkHighlighter;
+  private SqlLineHighlighter defaultHighlighter;
+  private SqlLineHighlighter lightHighlighter;
 
-  public void setUp() throws Exception {
-    sqlLine = getSqlLine();
-    highlighter = new SqlLineHighlighter(sqlLine);
+  @Before public void setUp() throws Exception {
+    darkSqlLine = getSqlLine(SqlLineOpts.DARK_SCHEME);
+    defaultSqlline = getSqlLine(SqlLineOpts.DEFAULT);
+    lightSqlLine = getSqlLine(SqlLineOpts.LIGHT_SCHEME);
+    darkHighlighter = new SqlLineHighlighter(darkSqlLine);
+    defaultHighlighter = new SqlLineHighlighter(defaultSqlline);
+    lightHighlighter = new SqlLineHighlighter(lightSqlLine);
   }
 
-  public void tearDown() {
-    sqlLine = null;
-    highlighter = null;
+  @After public void tearDown() {
+    darkSqlLine = null;
+    defaultSqlline = null;
+    lightSqlLine = null;
+    darkHighlighter = null;
+    defaultHighlighter = null;
+    lightHighlighter = null;
   }
 
-  public void testCommands() {
+  @Test public void testCommands() {
     String[] linesRequiredToBeCommands = {
         "!set",
         "!commandhandler",
@@ -58,11 +73,11 @@ public class SqlLineHighlighterTest extends TestCase {
       ExpectedHighlightStyle expectedStyle =
           new ExpectedHighlightStyle(line.length());
       expectedStyle.commands.set(0, line.length());
-      checkLine(sqlLine, line, expectedStyle, highlighter);
+      checkLine(line, expectedStyle);
     }
   }
 
-  public void testKeywords() {
+  @Test public void testKeywords() {
     String[] linesRequiredToBeKeywords = {
         "from",
         "outer",
@@ -77,11 +92,11 @@ public class SqlLineHighlighterTest extends TestCase {
       ExpectedHighlightStyle expectedStyle =
           new ExpectedHighlightStyle(line.length());
       expectedStyle.keywords.set(0, line.length());
-      checkLine(sqlLine, line, expectedStyle, highlighter);
+      checkLine(line, expectedStyle);
     }
   }
 
-  public void testSingleQuotedStrings() {
+  @Test public void testSingleQuotedStrings() {
     String[] linesRequiredToBeSingleQuoted = {
         "'from'",
         "''''",
@@ -97,11 +112,11 @@ public class SqlLineHighlighterTest extends TestCase {
       ExpectedHighlightStyle expectedStyle =
           new ExpectedHighlightStyle(line.length());
       expectedStyle.singleQuotes.set(0, line.length());
-      checkLine(sqlLine, line, expectedStyle, highlighter);
+      checkLine(line, expectedStyle);
     }
   }
 
-  public void testDoubleQuotedStrings() {
+  @Test public void testDoubleQuotedStrings() {
     String[] linesRequiredToBeDoubleQuoted = {
         "\"",
         "\"\"",
@@ -118,11 +133,11 @@ public class SqlLineHighlighterTest extends TestCase {
       ExpectedHighlightStyle expectedStyle =
           new ExpectedHighlightStyle(line.length());
       expectedStyle.doubleQuotes.set(0, line.length());
-      checkLine(sqlLine, line, expectedStyle, highlighter);
+      checkLine(line, expectedStyle);
     }
   }
 
-  public void testCommentedStrings() {
+  @Test public void testCommentedStrings() {
     String[] linesRequiredToBeComments = {
         "-- 'asdasd'asd",
         "--select",
@@ -137,11 +152,11 @@ public class SqlLineHighlighterTest extends TestCase {
       ExpectedHighlightStyle expectedStyle =
           new ExpectedHighlightStyle(line.length());
       expectedStyle.comments.set(0, line.length());
-      checkLine(sqlLine, line, expectedStyle, highlighter);
+      checkLine(line, expectedStyle);
     }
   }
 
-  public void testNumberStrings() {
+  @Test public void testNumberStrings() {
     String[] linesRequiredToBeNumbers = {
         "123456789",
         "0123",
@@ -152,21 +167,18 @@ public class SqlLineHighlighterTest extends TestCase {
       ExpectedHighlightStyle expectedStyle =
           new ExpectedHighlightStyle(line.length());
       expectedStyle.numbers.set(0, line.length());
-      checkLine(sqlLine, line, expectedStyle, highlighter);
+      checkLine(line, expectedStyle);
     }
   }
 
-  public void testComplexStrings() throws IOException {
-    final SqlLine sqlLine = getSqlLine();
-    final SqlLineHighlighter highlighter = new SqlLineHighlighter(sqlLine);
-
+  @Test public void testComplexStrings() {
     // command with argument
     String line = "!set version";
     ExpectedHighlightStyle expectedStyle =
         new ExpectedHighlightStyle(line.length());
     expectedStyle.commands.set(0, "!set".length());
     expectedStyle.defaults.set("!set".length(), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     // command with quoted argument
     line = "!set csvdelimiter '\"'";
@@ -174,7 +186,7 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.commands.set(0, "!set".length());
     expectedStyle.defaults.set("!set".length(), line.indexOf("'\"'"));
     expectedStyle.singleQuotes.set(line.indexOf("'\"'"), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     // command with double quoted argument
     line = "!set csvdelimiter \"'\"";
@@ -182,7 +194,7 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.commands.set(0, "!set".length());
     expectedStyle.defaults.set("!set".length(), line.indexOf("\"'\""));
     expectedStyle.doubleQuotes.set(line.indexOf("\"'\""), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     // command with double quoted argument and \n
     line = "!set csvdelimiter \"'\n\"";
@@ -190,14 +202,14 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.commands.set(0, "!set".length());
     expectedStyle.defaults.set("!set".length(), line.indexOf("\"'\n\""));
     expectedStyle.doubleQuotes.set(line.indexOf("\"'\n\""), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     line = "select '1'";
     expectedStyle = new ExpectedHighlightStyle(line.length());
     expectedStyle.keywords.set(0, "select".length());
     expectedStyle.defaults.set("select".length(), line.indexOf(' ') + 1);
     expectedStyle.singleQuotes.set(line.indexOf(' ') + 1, line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     //no spaces
     line = "select'1'as\"21\"";
@@ -207,7 +219,7 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.singleQuotes.set(line.indexOf('\''), line.indexOf("as"));
     expectedStyle.keywords.set(line.indexOf("as"), line.indexOf("\"21\""));
     expectedStyle.doubleQuotes.set(line.indexOf("\"21\""), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     //not valid sql with comments /**/ and not ended quoted line
     line = "select/*123'1'*/'as\"21\"";
@@ -216,7 +228,7 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.comments
         .set(line.indexOf("/*123'1'*/"), line.indexOf("'as\"21\""));
     expectedStyle.singleQuotes.set(line.indexOf("'as\"21\""), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     //not valid sql with not ended multiline comment
     line = "select /*\n * / \n 123 as \"q\" \nfrom dual\n where\n 1 = 1";
@@ -225,7 +237,7 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.defaults.set("select".length());
     expectedStyle.comments
         .set(line.indexOf("/*\n"), line.length());
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
 
     //multiline sql with comments
     line = "select/*multiline\ncomment\n*/0 as \"0\","
@@ -257,24 +269,24 @@ public class SqlLineHighlighterTest extends TestCase {
     expectedStyle.numbers.set(line.indexOf("1=1"));
     expectedStyle.defaults.set(line.indexOf("=1"));
     expectedStyle.numbers.set(line.indexOf("=1") + 1);
-    checkLine(sqlLine, line, expectedStyle, highlighter);
+    checkLine(line, expectedStyle);
   }
 
-  private void checkLine(
+  private void checkHighlightedLine(
       SqlLine sqlLine,
       String line,
       ExpectedHighlightStyle expectedHighlightStyle,
       SqlLineHighlighter highlighter) {
-    AttributedString attributedString =
+    final AttributedString attributedString =
         highlighter.highlight(sqlLine.getLineReader(), line);
-    Application.HighlightConfig highlightConfig = sqlLine.getHighlightConfig();
-    int commandsStyle = highlightConfig.getCommandStyle().getStyle();
-    int keyWordStyle = highlightConfig.getSqlKeywordStyle().getStyle();
-    int singleQuoteStyle = highlightConfig.getQuotedStyle().getStyle();
-    int doubleQuoteStyle = highlightConfig.getDoubleQuotedStyle().getStyle();
-    int commentsStyle = highlightConfig.getCommentedStyle().getStyle();
-    int numbersStyle = highlightConfig.getNumbersStyle().getStyle();
-    int defaultStyle = highlightConfig.getDefaultStyle().getStyle();
+    final HighlightStyle highlightStyle = sqlLine.getHighlightStyle();
+    int commandsStyle = highlightStyle.getCommandStyle().getStyle();
+    int keyWordStyle = highlightStyle.getSqlKeywordStyle().getStyle();
+    int singleQuoteStyle = highlightStyle.getQuotedStyle().getStyle();
+    int doubleQuoteStyle = highlightStyle.getDoubleQuotedStyle().getStyle();
+    int commentsStyle = highlightStyle.getCommentedStyle().getStyle();
+    int numbersStyle = highlightStyle.getNumbersStyle().getStyle();
+    int defaultStyle = highlightStyle.getDefaultStyle().getStyle();
 
     for (int i = 0; i < line.length(); i++) {
       checkSymbolStyle(line, i, expectedHighlightStyle.commands,
@@ -298,6 +310,32 @@ public class SqlLineHighlighterTest extends TestCase {
       checkSymbolStyle(line, i, expectedHighlightStyle.defaults,
           attributedString, defaultStyle, "default");
     }
+  }
+
+  private void checkDefaultLine(
+      SqlLine sqlLine,
+      String line) {
+    final AttributedString attributedString =
+        defaultHighlighter.highlight(sqlLine.getLineReader(), line);
+    int defaultStyle = AttributedStyle.DEFAULT.getStyle();
+
+    for (int i = 0; i < line.length(); i++) {
+      if (Character.isWhitespace(line.charAt(i))) {
+        continue;
+      }
+      assertEquals(getFailedStyleMessage(line, i, "default"),
+          i == 0 ? defaultStyle + 32 : defaultStyle,
+          attributedString.styleAt(i).getStyle());
+    }
+  }
+
+  private void checkLine(
+      String line, ExpectedHighlightStyle expectedHighlightStyle) {
+    checkHighlightedLine(
+        darkSqlLine, line, expectedHighlightStyle, darkHighlighter);
+    checkHighlightedLine(
+        lightSqlLine, line, expectedHighlightStyle, lightHighlighter);
+    checkDefaultLine(defaultSqlline, line);
   }
 
   private void checkSymbolStyle(
@@ -336,7 +374,7 @@ public class SqlLineHighlighterTest extends TestCase {
         + (positive ? "" : "not ") + "be " + style + " style";
   }
 
-  private SqlLine getSqlLine() throws IOException {
+  private SqlLine getSqlLine(String colorScheme) throws IOException {
     SqlLine sqlLine = new SqlLine();
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     PrintStream sqllineOutputStream =
@@ -345,6 +383,7 @@ public class SqlLineHighlighterTest extends TestCase {
     sqlLine.setErrorStream(sqllineOutputStream);
     final InputStream is = new ByteArrayInputStream(new byte[0]);
     sqlLine.begin(new String[]{"-e", "!set maxwidth 80"}, is, false);
+    sqlLine.getOpts().setColorScheme(colorScheme);
     return sqlLine;
   }
 

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -313,7 +313,7 @@ public class SqlLineHighlighterTest {
     int commandsStyle = highlightStyle.getCommandStyle().getStyle();
     int keyWordStyle = highlightStyle.getSqlKeywordStyle().getStyle();
     int singleQuoteStyle = highlightStyle.getQuotedStyle().getStyle();
-    int doubleQuoteStyle = highlightStyle.getDoubleQuotedStyle().getStyle();
+    int doubleQuoteStyle = highlightStyle.getSqlIdentifierStyle().getStyle();
     int commentsStyle = highlightStyle.getCommentedStyle().getStyle();
     int numbersStyle = highlightStyle.getNumbersStyle().getStyle();
     int defaultStyle = highlightStyle.getDefaultStyle().getStyle();

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -26,11 +26,11 @@ import org.junit.Test;
 import junit.framework.TestCase;
 
 /**
- * SqlLineHighlighterTest.
+ * Tests for sql and command syntax highlighting in sqlline.
  */
 public class SqlLineHighlighterTest extends TestCase {
   @Test
-  public void testHandleNumbers() {
+  public void testHandleNumbers() throws IOException {
     SqlLineHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
     String inputString = "select 1+1, 2*2, 3-1, 1/1 from dual where 0=0";
     BitSet expectedBitSet = new BitSet(inputString.length());
@@ -55,7 +55,7 @@ public class SqlLineHighlighterTest extends TestCase {
   }
 
   @Test
-  public void testHandleKeyWords() {
+  public void testHandleKeyWords() throws IOException {
     SqlLineHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
     String inputString = "select 1+1, 2*2, 3-1, 1/1 from dual where 0=0";
     BitSet expectedBitSet = new BitSet(inputString.length());

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -1,0 +1,41 @@
+package sqlline;
+
+import org.jline.reader.EOFError;
+import org.jline.reader.Parser;
+import org.jline.reader.impl.DefaultHighlighter;
+import org.jline.reader.impl.DefaultParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SqlLineHighlighterTest {
+  @Test
+  public void testHighlight() {
+    DefaultHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
+    //highlighter.highlight()
+
+  }
+
+  @Test
+  public void testSqlLineParserForWrongLines() {
+    DefaultParser parser = new SqlLineParser(new SqlLine())
+        .eofOnUnclosedQuote(true)
+        .eofOnEscapedNewLine(true);
+    Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
+    String[] successfulLinesToCheck = new String[] {
+        "!sql",
+        "   !all",
+        " \n select",
+        " \n test ",
+        "  test ';",
+        " \n test ';'\";",
+    };
+    for (String line : successfulLinesToCheck) {
+      try {
+        parser.parse(line, line.length(), acceptLine);
+        Assert.fail("Missing closing quote or semicolon for line " + line);
+      } catch (EOFError eofError) {
+        //ok
+      }
+    }
+  }
+}

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -28,7 +28,6 @@ import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -365,19 +364,16 @@ public class SqlLineHighlighterTest {
       // in case of default there is no SQLKeyWords
       // or sqlIdentifierQuote retrieval and as a result no connection usage
       if (SqlLineOpts.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
-        assertFalse(
-            sqlLineHighlighter.checkIfConnectionPresent(
-                sqlLine.getDatabaseConnection().connection));
-      } else {
         assertTrue(
-            sqlLineHighlighter.checkIfConnectionPresent(
-                sqlLine.getDatabaseConnection().connection));
+            sqlLineHighlighter.getConnection2rules().isEmpty());
+      } else {
+        assertEquals("Only one connection should be",
+            1, sqlLineHighlighter.getConnection2rules().size());
       }
       sqlLine.getDatabaseConnection().close();
 
-      assertFalse("Check colorScheme " + sqlLine.getOpts().getColorScheme(),
-          sqlLineHighlighter.checkIfConnectionPresent(
-              sqlLine.getDatabaseConnection().connection));
+      assertTrue("Check colorScheme " + sqlLine.getOpts().getColorScheme(),
+          sqlLineHighlighter.getConnection2rules().isEmpty());
     }
   }
 
@@ -451,19 +447,16 @@ public class SqlLineHighlighterTest {
       // in case of default there is no SQLKeyWords
       // or sqlIdentifierQuote retrieval and as a result no connection usage
       if (SqlLineOpts.DEFAULT.equals(sqlLine.getOpts().getColorScheme())) {
-        assertFalse(
-            sqlLineHighlighter.checkIfConnectionPresent(
-                sqlLine.getDatabaseConnection().connection));
-      } else {
         assertTrue(
-            sqlLineHighlighter.checkIfConnectionPresent(
-                sqlLine.getDatabaseConnection().connection));
+            sqlLineHighlighter.getConnection2rules().isEmpty());
+      } else {
+        assertEquals(1,
+            sqlLineHighlighter.getConnection2rules().size());
       }
       sqlLine.getDatabaseConnection().close();
 
-      assertFalse("Check colorScheme " + sqlLine.getOpts().getColorScheme(),
-          sqlLineHighlighter.checkIfConnectionPresent(
-              sqlLine.getDatabaseConnection().connection));
+      assertTrue("Check colorScheme " + sqlLine.getOpts().getColorScheme(),
+          sqlLineHighlighter.getConnection2rules().isEmpty());
     }
   }
 

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
+import java.util.Collections;
 
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStyle;
@@ -123,7 +124,7 @@ public class SqlLineHighlighterTest {
         "\"from\"",
         "\"''\"",
         "\"test '' \n''select\"",
-        "\"/* \"",
+        "\"/* \\\"kjh\"",
         "\"/*   \"",
         "\"--   \"",
         "\"\n  \n\""
@@ -270,6 +271,35 @@ public class SqlLineHighlighterTest {
     expectedStyle.defaults.set(line.indexOf("=1"));
     expectedStyle.numbers.set(line.indexOf("=1") + 1);
     checkLine(line, expectedStyle);
+  }
+
+  @Test public void testSqlKeywordsFromDatabase() {
+    String[] linesRequiredToBeNumbers = {
+        "minus",
+        "today",
+    };
+
+    for (String line : linesRequiredToBeNumbers) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.defaults.set(0, line.length());
+      checkLine(line, expectedStyle);
+    }
+
+    DispatchCallback dc = new DispatchCallback();
+    darkSqlLine.runCommands(
+        Collections.singletonList("!connect "
+            + SqlLineArgsTest.ConnectionSpec.H2.url + " "
+            + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
+        dc);
+
+    for (String line : linesRequiredToBeNumbers) {
+      ExpectedHighlightStyle expectedStyle =
+          new ExpectedHighlightStyle(line.length());
+      expectedStyle.keywords.set(0, line.length());
+      checkHighlightedLine(
+          darkSqlLine, line, expectedStyle, darkHighlighter);
+    }
   }
 
   private void checkHighlightedLine(

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -1,41 +1,146 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
 package sqlline;
 
-import org.jline.reader.EOFError;
-import org.jline.reader.Parser;
-import org.jline.reader.impl.DefaultHighlighter;
-import org.jline.reader.impl.DefaultParser;
-import org.junit.Assert;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
 import org.junit.Test;
 
-public class SqlLineHighlighterTest {
-  @Test
-  public void testHighlight() {
-    DefaultHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
-    //highlighter.highlight()
+import junit.framework.TestCase;
 
+/**
+ * SqlLineHighlighterTest.
+ */
+public class SqlLineHighlighterTest extends TestCase {
+  @Test
+  public void testHandleNumbers() {
+    SqlLineHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
+    String inputString = "select 1+1, 2*2, 3-1, 1/1 from dual where 0=0";
+    BitSet expectedBitSet = new BitSet(inputString.length());
+    expectedBitSet.set(7);
+    expectedBitSet.set(9);
+    expectedBitSet.set(12);
+    expectedBitSet.set(14);
+    expectedBitSet.set(17);
+    expectedBitSet.set(19);
+    expectedBitSet.set(22);
+    expectedBitSet.set(24);
+    expectedBitSet.set(42);
+    expectedBitSet.set(44);
+
+    BitSet numberBitSet = new BitSet(inputString.length());
+    for (int i = 0; i < inputString.length(); i++) {
+      if (Character.isDigit(inputString.charAt(i))) {
+        i = highlighter.handleNumbers(inputString, numberBitSet, i);
+      }
+    }
+    assertEquals(expectedBitSet, numberBitSet);
   }
 
   @Test
-  public void testSqlLineParserForWrongLines() {
-    DefaultParser parser = new SqlLineParser(new SqlLine())
-        .eofOnUnclosedQuote(true)
-        .eofOnEscapedNewLine(true);
-    Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
-    String[] successfulLinesToCheck = new String[] {
-        "!sql",
-        "   !all",
-        " \n select",
-        " \n test ",
-        "  test ';",
-        " \n test ';'\";",
+  public void testHandleKeyWords() {
+    SqlLineHighlighter highlighter = new SqlLineHighlighter(new SqlLine());
+    String inputString = "select 1+1, 2*2, 3-1, 1/1 from dual where 0=0";
+    BitSet expectedBitSet = new BitSet(inputString.length());
+    expectedBitSet.set(7);
+    expectedBitSet.set(9);
+    expectedBitSet.set(12);
+    expectedBitSet.set(14);
+    expectedBitSet.set(17);
+    expectedBitSet.set(19);
+    expectedBitSet.set(22);
+    expectedBitSet.set(24);
+    expectedBitSet.set(42);
+    expectedBitSet.set(44);
+
+    BitSet numberBitSet = new BitSet(inputString.length());
+    for (int i = 0; i < inputString.length(); i++) {
+      if (Character.isDigit(inputString.charAt(i))) {
+        i = highlighter.handleNumbers(inputString, numberBitSet, i);
+      }
+    }
+    assertEquals(expectedBitSet, numberBitSet);
+  }
+
+  @Test
+  public void testBoldStrings() throws IOException {
+    SqlLine sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream sqllineOutputStream =
+        new PrintStream(os, false, StandardCharsets.UTF_8.name());
+    sqlLine.setOutputStream(sqllineOutputStream);
+    sqlLine.setErrorStream(sqllineOutputStream);
+    final InputStream is = new ByteArrayInputStream(new byte[0]);
+    sqlLine.begin(new String[]{"-e", "!set maxwidth 80"}, is, false);
+    SqlLineHighlighter sqlLineHighlighter = new SqlLineHighlighter(sqlLine);
+    String[] stringsRequiredToBeBold = new String[] {
+        "!set",
+        "!commandhandler",
+        "select",
+        "values",
+        "where",
+        "join",
+        "!connect"
     };
-    for (String line : successfulLinesToCheck) {
-      try {
-        parser.parse(line, line.length(), acceptLine);
-        Assert.fail("Missing closing quote or semicolon for line " + line);
-      } catch (EOFError eofError) {
-        //ok
+    for (String str: stringsRequiredToBeBold) {
+      AttributedString stringSelect =
+          sqlLineHighlighter.highlight(sqlLine.getLineReader(), str);
+      for (int i = 0; i < str.length(); i++) {
+        assertTrue("String '" + str + "' should be in bold",
+            isBold(stringSelect.styleAt(i)));
       }
     }
   }
+
+  @Test
+  public void testNotBoldStrings() throws IOException {
+    SqlLine sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream sqllineOutputStream =
+        new PrintStream(os, false, StandardCharsets.UTF_8.name());
+    sqlLine.setOutputStream(sqllineOutputStream);
+    sqlLine.setErrorStream(sqllineOutputStream);
+    final InputStream is = new ByteArrayInputStream(new byte[0]);
+    sqlLine.begin(new String[]{"-e", "!set maxwidth 80"}, is, false);
+    SqlLineHighlighter sqlLineHighlighter = new SqlLineHighlighter(sqlLine);
+    String[] stringsRequiredToBeBold = new String[] {
+        "!st",
+        "!ohandler",
+        "/* select */",
+        "--values",
+        "'where'",
+        "\"join\""
+    };
+    for (String str: stringsRequiredToBeBold) {
+      AttributedString stringSelect =
+          sqlLineHighlighter.highlight(sqlLine.getLineReader(), str);
+      for (int i = 0; i < str.length(); i++) {
+        assertFalse("String '" + str + "' should be not in bold",
+            isBold(stringSelect.styleAt(i)));
+      }
+    }
+  }
+
+  private boolean isBold(AttributedStyle style) {
+    return style.getMask() % 2 != 0 && style.getStyle() % 2 != 0;
+  }
 }
+
+// End SqlLineHighlighterTest.java

--- a/src/test/java/sqlline/SqlLineParserTest.java
+++ b/src/test/java/sqlline/SqlLineParserTest.java
@@ -23,10 +23,8 @@ import org.junit.Test;
 public class SqlLineParserTest {
   @Test
   public void testSqlLineParserForOkLines() {
-    final DefaultParser parser = new SqlLineParser(new SqlLine())
-        .eofOnUnclosedQuote(true)
-        .eofOnEscapedNewLine(true);
-    Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
+    final DefaultParser parser = new SqlLineParser(new SqlLine());
+    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
     final String[] lines = {
         // commands
         "!set",
@@ -75,10 +73,8 @@ public class SqlLineParserTest {
 
   @Test
   public void testSqlLineParserForWrongLines() {
-    final DefaultParser parser = new SqlLineParser(new SqlLine())
-        .eofOnUnclosedQuote(true)
-        .eofOnEscapedNewLine(true);
-    Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
+    final DefaultParser parser = new SqlLineParser(new SqlLine());
+    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
     final String[] lines = {
         "!sql",
         "   !all",


### PR DESCRIPTION
The PR provides implementation of sql syntax highlighting and closes #164.
The default keywords set retrieving moved to `Application` class to make the logic common both for highlighter and completers. As a result the source of default keywords set could be customized.
It also provides several color schemes (chester/dark/dracula/light/ozbsidian/solarized/vs2010) and 2 possibilities to switch between them: via property setting and via `alt-h` key combination. The set of colorschemes could be customized via `Application`.
The tests include possibility to check against several color schemes, please have a look at `sqlline.SqlLineHighlighterTest#setUp`

There is a list of entities for which there could be specified their own style (not only color but also text style like _italic_, **bold**, ~strike~ and etc. or a combination of such styles)

- sqlline commands (not sql but could be also highlighted)
- keyword (based on default one `sqlline.Application#getDefaultKeyWordSet` + `java.sql.DatabaseMetaData#getSQLKeywords` for the specific connection)
- comment (both one line `--` and multiline `/* */`)
- numbers
- single quoted strings 
- sql identifiers (quoted with a symbol from `java.sql.DatabaseMetaData#getIdentifierQuoteString` or `"` as default)