### PR TITLE
[SQLLINE-177] Make use of LineReader.HISTORY_SIZE and LineReader.HIST…

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -2853,6 +2853,21 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           Defaults to 15.
         </para>
       </sect1>
+      <sect1 id="setting_maxhistoryfilerows">
+        <title>maxhistoryfilerows</title>
+        <para>
+            The maximum number of history rows to store
+            in history file. Defaults to 10000
+            (org.jline.reader.impl.history.DefaultHistory.DEFAULT_HISTORY_FILE_SIZE).
+        </para>
+    </sect1>
+    <sect1 id="setting_maxhistoryrows">
+        <title>maxhistoryrows</title>
+        <para>
+            The maximum number of history rows to store in memory.
+            Defaults to 500 (org.jline.reader.impl.history.DefaultHistory.DEFAULT_HISTORY_SIZE).
+        </para>
+    </sect1>
       <sect1 id="setting_maxwidth">
         <title>maxwidth</title>
         <para>

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -13,6 +13,8 @@ package sqlline;
 
 import java.io.File;
 
+import org.jline.reader.impl.history.DefaultHistory;
+
 /**
  * Built-in properties of SqlLine.
  *
@@ -42,6 +44,11 @@ public enum BuiltInProperty implements SqlLineProperty {
   // the terminal configuration
   MAX_HEIGHT("maxHeight", Type.INTEGER, 80, false, false),
   MAX_WIDTH("maxWidth", Type.INTEGER, 80, false, false),
+
+  MAX_HISTORY_ROWS("maxHistoryRows",
+      Type.INTEGER, DefaultHistory.DEFAULT_HISTORY_SIZE),
+  MAX_HISTORY_FILE_ROWS("maxHistoryFileRows",
+      Type.INTEGER, DefaultHistory.DEFAULT_HISTORY_FILE_SIZE),
 
   NUMBER_FORMAT("numberFormat", Type.STRING, DEFAULT),
   NULL_VALUE("nullValue", Type.STRING, DEFAULT),

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -87,6 +87,10 @@ variables:\
 \nmaxColumnWidth  integer    The maximum width to use when displaying columns\
 \nmaxHeight       integer    The maximum height of the terminal\
 \nmaxWidth        integer    The maximum width of the terminal\
+\nmaxHistoryFileRows integer The maximum number of history rows \
+\n                           to store in history file\
+\nmaxHistoryRows  integer    The maximum number of history rows \
+\n                           to store in memory\
 \nnullValue       String     Use String in place of  NULL values\
 \nnumberFormat    pattern    Format numbers using DecimalFormat pattern\
 \noutputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json\
@@ -233,6 +237,8 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --force=[true/false]            continue running script even after errors\n \
 \  --maxWidth=MAXWIDTH             the maximum width of the terminal\n \
 \  --maxColumnWidth=MAXCOLWIDTH    the maximum width to use when displaying columns\n \
+\  --maxHistoryFileRows=ROWS       the maximum number of history rows to store in history file\n \
+\  --maxHistoryRows=ROWS           the maximum number of history rows to store in memory\n \
 \  --silent=[true/false]           be more silent\n \
 \  --autosave=[true/false]         automatically save preferences\n \
 \  --outputformat=[table/vertical/csv/tsv/xmlattrs/xmlelements/json]\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -110,6 +110,8 @@ historyfile
 incremental
 isolation
 maxcolumnwidth
+maxHistoryFileRows
+maxHistoryRows
 maxwidth
 nullValue
 numberformat
@@ -234,6 +236,8 @@ historyfile
 incremental
 isolation
 maxcolumnwidth
+maxHistoryFileRows
+maxHistoryRows
 maxwidth
 nullValue
 numberformat
@@ -1106,6 +1110,10 @@ isolation       LEVEL      Set transaction isolation level
 maxColumnWidth  integer    The maximum width to use when displaying columns
 maxHeight       integer    The maximum height of the terminal
 maxWidth        integer    The maximum width of the terminal
+maxHistoryFileRows integer The maximum number of history rows
+                           to store in history file
+maxHistoryRows  integer    The maximum number of history rows
+                           to store in memory
 nullValue       String     Use String in place of  NULL values
 numberFormat    pattern    Format numbers using DecimalFormat pattern
 outputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json
@@ -2020,6 +2028,8 @@ historyfile
 incremental
 isolation
 maxcolumnwidth
+maxHistoryFileRows
+maxHistoryRows
 maxwidth
 nullValue
 numberformat
@@ -2084,7 +2094,15 @@ The default transaction isolation that will be used for new connections. To chan
 
 maxcolumnwidth
 
-The maximum column width to display for each colummn before truncating data when using the "table" outputformat. Defaults to 15.
+The maximum column width to display for each column before truncating data when using the "table" outputformat. Defaults to 15.
+
+maxHistoryFileRows
+
+The maximum number of history rows to store in history file. Defaults to 10000 (org.jline.reader.impl.history.DefaultHistory.DEFAULT_HISTORY_FILE_SIZE).
+
+maxHistoryRows
+
+The maximum number of history rows to store in memory. Defaults to 500 (org.jline.reader.impl.history.DefaultHistory.DEFAULT_HISTORY_SIZE).
 
 maxwidth
 


### PR DESCRIPTION
The PR allows to limit the number of history rows in history file and in memory by usage of jline linereader's variables `org.jline.reader.LineReader#HISTORY_SIZE` and `org.jline.reader.LineReader#HISTORY_FILE_SIZE`

fixes #177 