### PR TITLE
[SQLLINE-179] Add <useManifestOnlyJar>false</useManifestOnlyJar> sett…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <useManifestOnlyJar>false</useManifestOnlyJar>
           <systemPropertyVariables>
             <!-- Run tests in Turkish to make sure that they don't depend on
                  locale. Turkish is a notoriously tricky locale. -->


### PR DESCRIPTION
The PR allows to use not only manifest jar for test to allow to run jmockit's agent especially while running on JDK10
fixes #179 