### PR TITLE
[SQLLINE-181] Use <code> tag rather than <tt> as <tt> is deprecated

### DIFF
--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -246,8 +246,8 @@ public class SqlLineArgsTest {
 
   /** Test case for
    * <a href="https://github.com/julianhyde/sqlline/issues/72">[SQLLINE-72]
-   * Allow quoted file names (including spaces) in <tt>!record</tt>,
-   * <tt>!run</tt> and <tt>!script</tt> commands</a>. */
+   * Allow quoted file names (including spaces) in <code>!record</code>,
+   * <code>!run</code> and <code>!script</code> commands</a>. */
   @Test
   public void testScriptFilenameWithSpace() {
     final String scriptText = "values 10 + 23;\n"


### PR DESCRIPTION
The PR makes use of  `<code>` instead of `<tt>` as `<tt>` is not supported by html5
