### PR TITLE
[SQLLINE-164] Fix the inifinite loop, add widget, add tests for both cases

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -2770,7 +2770,7 @@ java.sql.SQLException: ORA-00942: table or view does not exist
         <para>
             If <literal>chester</literal>/<literal>dark</literal>
             /<literal>dracula</literal>/<literal>light</literal>
-            /<literal>ozbsidian</literal>/<literal>solarized</literal>
+            /<literal>obsidian</literal>/<literal>solarized</literal>
             /<literal>vs2010</literal>,
             then this scheme will be used for command/sql syntax highlighting.
             If <literal>default</literal> then there is no syntax highlighting.

--- a/src/main/java/sqlline/BuiltInHighlightStyle.java
+++ b/src/main/java/sqlline/BuiltInHighlightStyle.java
@@ -29,7 +29,7 @@ import static sqlline.AttributedStyles.*;
  * Gillis's Colour schemes for Oracle SQL Developer</a> (not the same but more
  * or less similar).
  *
- * <p>Similarly, the {@link #OZBSIDIAN} style is inspired by
+ * <p>Similarly, the {@link #OBSIDIAN} style is inspired by
  * <a href="https://github.com/ozmoroz/ozbsidian-sqldeveloper">
  * ozmoroz's OzBsidian colour scheme for Oracle SQL Developer</a>.
  *
@@ -42,7 +42,7 @@ enum BuiltInHighlightStyle {
   DRACULA(BOLD_MAGENTA, BOLD_WHITE, GREEN, RED, ITALIC_CYAN, YELLOW, WHITE),
   SOLARIZED(BOLD_YELLOW, BOLD_BLUE, GREEN, RED, ITALIC_BRIGHT, CYAN, BLUE),
   VS2010(BOLD_BLUE, BOLD_WHITE, RED, MAGENTA, ITALIC_GREEN, BRIGHT, WHITE),
-  OZBSIDIAN(BOLD_GREEN, BOLD_WHITE, RED, MAGENTA, ITALIC_BRIGHT, YELLOW, WHITE);
+  OBSIDIAN(BOLD_GREEN, BOLD_WHITE, RED, MAGENTA, ITALIC_BRIGHT, YELLOW, WHITE);
 
   final HighlightStyle style;
 

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -29,6 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
+import java.util.WeakHashMap;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.impl.DefaultHighlighter;
@@ -46,7 +46,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
   private final SqlLine sqlLine;
   private final Set<String> defaultKeywordSet;
   private final Map<Connection, HighlightRule> connection2rules =
-      new HashMap<>();
+      new WeakHashMap<>();
 
   public SqlLineHighlighter(SqlLine sqlLine) throws IOException {
     this.sqlLine = sqlLine;

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -85,6 +85,7 @@ public class SqlLineOpts implements Completer {
       Collections.unmodifiableMap(
           new HashMap<SqlLineProperty, SqlLineProperty.Writer>() {
             {
+              put(COLOR_SCHEME, SqlLineOpts.this::setColorScheme);
               put(CSV_QUOTE_CHARACTER, SqlLineOpts.this::setCsvQuoteCharacter);
               put(DATE_FORMAT, SqlLineOpts.this::setDateFormat);
               put(HISTORY_FILE, SqlLineOpts.this::setHistoryFile);
@@ -477,8 +478,9 @@ public class SqlLineOpts implements Completer {
       propertiesMap.put(COLOR_SCHEME, colorScheme);
       return;
     }
-    throw new IllegalArgumentException("Possible values are: "
-        + new TreeSet<>(BuiltInHighlightStyle.BY_NAME.keySet()));
+    throw new IllegalArgumentException(
+        sqlLine.loc("unknown-colorscheme", colorScheme,
+            new TreeSet<>(BuiltInHighlightStyle.BY_NAME.keySet())));
   }
 
   public String getColorScheme() {

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -70,7 +70,7 @@ variables:\
 \nautoCommit      true/false Enable/disable automatic transaction commit\
 \nautoSave        true/false Automatically save preferences\
 \ncolor           true/false Control whether color is used for display\
-\ncolorScheme     chester/dark/dracula/light/ozbsidian/solarized/vs2010\
+\ncolorScheme     chester/dark/dracula/light/obsidian/solarized/vs2010\
 \n                           Syntax highlight schema\
 \ncsvDelimiter    String     Delimiter in csv outputFormat\
 \ncsvQuoteCharacter char     Quote character in csv outputFormat\
@@ -223,7 +223,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  -log <file>                     file to write output\n \
 \  -ac <class name>                application configuration class name\n \
 \  --color=[true/false]            control whether color is used for display\n \
-\  --colorScheme=[chester/dark/dracula/light/ozbsidian/solarized/vs2010]\
+\  --colorScheme=[chester/dark/dracula/light/obsidian/solarized/vs2010]\
 \                                  Syntax highlight schema\n \
 \  --csvDelimiter=[delimiter]      Delimiter in csv outputFormat\n \
 \  --csvQuoteCharacter=[char]      Quote character in csv outputFormat\n \

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -161,6 +161,7 @@ autocommit-status: Autocommit status: {0}
 isolation-status: Transaction isolation: {0}
 isolation-level-not-supported: Transaction isolation level {0} is not supported. Default ({1}) will be used instead.
 unknown-format: Unknown output format "{0}". Possible values: {1}
+unknown-colorscheme: Unknown color scheme "{0}". Possible values: {1}
 
 closed: closed
 open: open

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -1097,7 +1097,7 @@ Variable        Value      Description
 autoCommit      true/false Enable/disable automatic transaction commit
 autoSave        true/false Automatically save preferences
 color           true/false Control whether color is used for display
-colorScheme     chester/dark/dracula/light/ozbsidian/solarized/vs2010
+colorScheme     chester/dark/dracula/light/obsidian/solarized/vs2010
                            Syntax highlight schema
 csvDelimiter    String     Delimiter in csv outputFormat
 csvQuoteCharacter char     Quote character in csv outputFormat
@@ -2067,7 +2067,7 @@ If true, then output to the terminal will use color for a more pleasing visual e
 
 colorScheme
 
-If chester/dark/dracula/light/ozbsidian/solarized/vs2010, then this scheme will be used for command/sql syntax highlighting. If default then there is no syntax highlighting.
+If chester/dark/dracula/light/obsidian/solarized/vs2010, then this scheme will be used for command/sql syntax highlighting. If default then there is no syntax highlighting.
 
 csvDelimiter
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1868,6 +1868,32 @@ public class SqlLineArgsTest {
     }
   }
 
+  @Test
+  public void testSetWrongColorScheme() {
+    final SqlLine sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    try {
+      SqlLine.Status status = begin(sqlLine, os, false);
+      // Here the status is SqlLine.Status.OTHER
+      // because of EOF as the result of InputStream which
+      // is not used in the current test so it is ok
+      assertThat(status, equalTo(SqlLine.Status.OTHER));
+      DispatchCallback dc = new DispatchCallback();
+      final String invalidColorScheme = "invalid";
+      sqlLine.runCommands(
+          Collections.singletonList(
+              "!set colorscheme " + invalidColorScheme), dc);
+      assertThat(os.toString("UTF8"),
+          containsString(sqlLine.loc("unknown-colorscheme", invalidColorScheme,
+              new TreeSet<>(BuiltInHighlightStyle.BY_NAME.keySet()))));
+      os.reset();
+    } catch (Exception e) {
+      // fail
+      throw new RuntimeException(e);
+    }
+  }
+
+
   /** Information necessary to create a JDBC connection. Specify one to run
    * tests against a different database. (hsqldb is the default.) */
   public static class ConnectionSpec {

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1893,7 +1893,6 @@ public class SqlLineArgsTest {
     }
   }
 
-
   /** Information necessary to create a JDBC connection. Specify one to run
    * tests against a different database. (hsqldb is the default.) */
   public static class ConnectionSpec {

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -11,7 +11,11 @@
 */
 package sqlline;
 
+import java.util.Objects;
+
 import junit.framework.TestCase;
+
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Test cases for SQLLine.
@@ -199,6 +203,22 @@ public class SqlLineTest extends TestCase {
     } catch (IllegalArgumentException e) {
       //ok
     }
+  }
+
+  public void testNextColorScheme() {
+    final SqlLine sqlLine = new SqlLine();
+    final String initialScheme = sqlLine.getOpts().getColorScheme();
+    String currentScheme = null;
+    // the artificial limit to check
+    // if finally we will come to the initial color scheme
+    final int limit = 10000;
+    int counter = 0;
+    while (counter++ < 10000 && !Objects.equals(initialScheme, currentScheme)) {
+      sqlLine.nextColorSchemeWidget();
+      currentScheme = sqlLine.getOpts().getColorScheme();
+    }
+    assertNotEquals(limit, counter);
+    assertEquals(initialScheme, currentScheme);
   }
 
   void assertEquals(String[][] expectedses, String[][] actualses) {


### PR DESCRIPTION
The PR addresses the changes requested at https://github.com/julianhyde/sqlline/issues/164#issuecomment-435799612 and https://github.com/julianhyde/sqlline/issues/164#issuecomment-435798147
1. Fix the infinite loop in case of wrong color scheme (test included)
2. Rename  'ozbsidian' => 'obsidian'
3. Add widget for color scheme switching (`alt-h`) and a test for its main method.