### PR TITLE
Add "mode" property to switch between emacs/vi modes

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -2958,6 +2958,24 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           command</link>.
         </para>
       </sect1>
+      <sect1 id="setting_prompt">
+        <title>prompt</title>
+        <para>
+            The tcsh-like format for how prompt is displayed.
+            For example, the setting '%[\033[1;33m%]sqlline%[\033[m%]>' yields
+            yellow sqlline and normal angle bracket.
+            Defaults to 'sqlline>'. If for the specific
+            database connection nickname is set then nickname will be used.
+        </para>
+      </sect1>
+      <sect1 id="setting_rightprompt">
+        <title>rightprompt</title>
+        <para>
+            The tcsh-like format for how right prompt is displayed.
+            The same patterns are applied as for prompt but it
+            does not care if nickname is set or not. Defaults to ''.
+        </para>
+      </sect1>
       <sect1 id="setting_rowlimit">
         <title>rowlimit</title>
         <para>

--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -2927,6 +2927,12 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           current width, falls back to 80.
         </para>
       </sect1>
+      <sect1 id="setting_mode">
+        <title>mode</title>
+        <para>
+          The editing mode to use in sqlline. Defaults to "emacs".
+        </para>
+      </sect1>
       <sect1 id="setting_nullvalue">
         <title>nullvalue</title>
         <para>

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -13,6 +13,7 @@ package sqlline;
 
 import java.io.File;
 
+import org.jline.reader.LineReader;
 import org.jline.reader.impl.history.DefaultHistory;
 
 /**
@@ -52,6 +53,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   MAX_HISTORY_FILE_ROWS("maxHistoryFileRows",
       Type.INTEGER, DefaultHistory.DEFAULT_HISTORY_FILE_SIZE),
 
+  MODE("mode", Type.STRING, LineReader.EMACS),
   NUMBER_FORMAT("numberFormat", Type.STRING, DEFAULT),
   NULL_VALUE("nullValue", Type.STRING, DEFAULT),
   SILENT("silent", Type.BOOLEAN, false),

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -56,6 +56,8 @@ public enum BuiltInProperty implements SqlLineProperty {
   NULL_VALUE("nullValue", Type.STRING, DEFAULT),
   SILENT("silent", Type.BOOLEAN, false),
   OUTPUT_FORMAT("outputFormat", Type.STRING, "table"),
+  PROMPT("prompt", Type.STRING, "sqlline> "),
+  RIGHT_PROMPT("rightPrompt", Type.STRING, ""),
   ROW_LIMIT("rowLimit", Type.INTEGER, 0),
   SHOW_ELAPSED_TIME("showElapsedTime", Type.BOOLEAN, true),
   SHOW_HEADER("showHeader", Type.BOOLEAN, true),

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1327,9 +1327,16 @@ public class Commands {
       return;
     }
 
-    int index = Integer.parseInt(parts[1]);
-    if (!sqlLine.getDatabaseConnections().setIndex(index)) {
-      sqlLine.error(sqlLine.loc("invalid-connection", "" + index));
+    boolean isNumber;
+    int index = Integer.MIN_VALUE;
+    try {
+      index = Integer.parseInt(parts[1]);
+      isNumber = true;
+    } catch (Exception e) {
+      isNumber = false;
+    }
+    if (!isNumber || !sqlLine.getDatabaseConnections().setIndex(index)) {
+      sqlLine.error(sqlLine.loc("invalid-connection", parts[1]));
       list("", callback); // list the current connections
       callback.setToFailure();
       return;

--- a/src/main/java/sqlline/Dialect.java
+++ b/src/main/java/sqlline/Dialect.java
@@ -11,7 +11,9 @@
 */
 package sqlline;
 
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Database-specific rule which is used for highlighting,
@@ -22,10 +24,18 @@ import java.util.Set;
  */
 interface Dialect {
   Set<String> DEFAULT_KEYWORD_SET = BuiltInDialect.initDefaultKeywordSet();
+  // SQL92 comment prefix is "--"
+  // sqlline also supports shell-style "#" prefix
+  String[] SQLLINE_ONE_LINE_COMMENTS = {"#", "--"};
 
   boolean containsKeyword(String keyword);
 
   Set<String> getOneLineComments();
+
+  default Set<String> getSqlLineOneLineComments() {
+    return Arrays.stream(
+        SQLLINE_ONE_LINE_COMMENTS).collect(Collectors.toSet());
+  }
 
   char getOpenQuote();
 

--- a/src/main/java/sqlline/Prompt.java
+++ b/src/main/java/sqlline/Prompt.java
@@ -21,35 +21,43 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+import org.jline.utils.StyleResolver;
+
 /**
- * Prompt customization.
+ * Customization for the prompt shown at the start of each line.
  */
 class Prompt {
-
   private static final String START_COLOR = "\\033";
 
   private static final Map<Character, Supplier<String>>
       DATE_TIME_FORMATS = Collections.unmodifiableMap(
-        new HashMap<Character, Supplier<String>>() {{
-          put('D', () -> getFormattedDateTime("yyyy-MM-dd HH:mm:ss.SSS"));
-          put('m', () -> getFormattedDateTime("mm"));
-          put('o', () -> getFormattedDateTime("MM"));
-          put('O', () -> getFormattedDateTime("MMM"));
-          put('P', () -> getFormattedDateTime("aa"));
-          put('r', () -> getFormattedDateTime("hh:mm"));
-          put('R', () -> getFormattedDateTime("HH:mm"));
-          put('s', () -> getFormattedDateTime("ss"));
-          put('w', () -> getFormattedDateTime("d"));
-          put('W', () -> getFormattedDateTime("E"));
-          put('y', () -> getFormattedDateTime("YY"));
-          put('Y', () -> getFormattedDateTime("YYYY"));
-        }}
-    );
+        new HashMap<Character, Supplier<String>>() {
+          {
+            put('D', () -> getFormattedDateTime("yyyy-MM-dd HH:mm:ss.SSS"));
+            put('m', () -> getFormattedDateTime("mm"));
+            put('o', () -> getFormattedDateTime("MM"));
+            put('O', () -> getFormattedDateTime("MMM"));
+            put('P', () -> getFormattedDateTime("aa"));
+            put('r', () -> getFormattedDateTime("hh:mm"));
+            put('R', () -> getFormattedDateTime("HH:mm"));
+            put('s', () -> getFormattedDateTime("ss"));
+            put('w', () -> getFormattedDateTime("d"));
+            put('W', () -> getFormattedDateTime("E"));
+            put('y', () -> getFormattedDateTime("YY"));
+            put('Y', () -> getFormattedDateTime("YYYY"));
+          }
+        });
+
+  private static final StyleResolver STYLE_RESOLVER =
+      new StyleResolver(s -> "");
 
   private Prompt() {
   }
 
-  static String getRightPrompt(SqlLine sqlLine) {
+  static AttributedString getRightPrompt(SqlLine sqlLine) {
     final int connectionIndex = sqlLine.getDatabaseConnections().getIndex();
     final String value = sqlLine.getOpts().get(BuiltInProperty.RIGHT_PROMPT);
     final String currentPrompt = String.valueOf((Object) null).equals(value)
@@ -57,7 +65,7 @@ class Prompt {
     return getPrompt(sqlLine, connectionIndex, currentPrompt);
   }
 
-  static String getPrompt(SqlLine sqlLine) {
+  static AttributedString getPrompt(SqlLine sqlLine) {
     final String defaultPrompt =
         String.valueOf(BuiltInProperty.PROMPT.defaultValue());
     final String currentPrompt = sqlLine.getOpts().get(BuiltInProperty.PROMPT);
@@ -81,9 +89,9 @@ class Prompt {
     }
   }
 
-  private static String getPrompt(
+  private static AttributedString getPrompt(
       SqlLine sqlLine, int connectionIndex, String prompt) {
-    StringBuilder promptStringBuilder = new StringBuilder();
+    AttributedStringBuilder promptStringBuilder = new AttributedStringBuilder();
     final DatabaseConnection databaseConnection =
         sqlLine.getDatabaseConnection();
     final DatabaseMetaData databaseMetaData = databaseConnection == null
@@ -101,7 +109,13 @@ class Prompt {
             switch (prompt.charAt(i + 1)) {
             case 'c':
               if (connectionIndex >= 0) {
-                promptStringBuilder.append(connectionIndex);
+                promptStringBuilder.append(String.valueOf(connectionIndex));
+              }
+              break;
+            case 'C':
+              if (connectionIndex >= 0) {
+                promptStringBuilder
+                    .append(String.valueOf(connectionIndex)).append(": ");
               }
               break;
             case 'd':
@@ -130,18 +144,13 @@ class Prompt {
               }
               break;
             case '[':
-              if (prompt.regionMatches(
-                  i + 2, START_COLOR, 0, START_COLOR.length())) {
-                int closeBracketIndex =
-                    prompt.indexOf("%]", i + 2 + START_COLOR.length());
-                if (closeBracketIndex > 0) {
-                  String color = prompt
-                      .substring(i + 2 + START_COLOR.length(),
-                          closeBracketIndex);
-                  promptStringBuilder.append('\033').append(color);
-                  i = closeBracketIndex;
-                  break;
-                }
+              int closeBracketIndex = prompt.indexOf("%]", i + 2);
+              if (closeBracketIndex > 0) {
+                String color = prompt.substring(i + 2, closeBracketIndex);
+                AttributedStyle style = STYLE_RESOLVER.resolve(color);
+                promptStringBuilder.style(style);
+                i = closeBracketIndex;
+                break;
               }
             // fall through if not a color
             case ':':
@@ -168,14 +177,14 @@ class Prompt {
         promptStringBuilder.append(prompt.charAt(i));
       }
     }
-    return promptStringBuilder.toString();
+    return promptStringBuilder.toAttributedString();
   }
 
-  private static String getDefaultPrompt(
+  private static AttributedString getDefaultPrompt(
       int connectionIndex, String url, String defaultPrompt) {
     String resultPrompt;
     if (url == null || url.length() == 0) {
-      return defaultPrompt;
+      return new AttributedString(defaultPrompt);
     } else {
       if (url.contains(";")) {
         url = url.substring(0, url.indexOf(";"));
@@ -187,7 +196,7 @@ class Prompt {
       if (resultPrompt.length() > 45) {
         resultPrompt = resultPrompt.substring(0, 45);
       }
-      return resultPrompt + "> ";
+      return new AttributedString(resultPrompt + "> ");
     }
   }
 

--- a/src/main/java/sqlline/Prompt.java
+++ b/src/main/java/sqlline/Prompt.java
@@ -1,0 +1,200 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import java.sql.DatabaseMetaData;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Prompt customization.
+ */
+class Prompt {
+
+  private static final String START_COLOR = "\\033";
+
+  private static final Map<Character, Supplier<String>>
+      DATE_TIME_FORMATS = Collections.unmodifiableMap(
+        new HashMap<Character, Supplier<String>>() {{
+          put('D', () -> getFormattedDateTime("yyyy-MM-dd HH:mm:ss.SSS"));
+          put('m', () -> getFormattedDateTime("mm"));
+          put('o', () -> getFormattedDateTime("MM"));
+          put('O', () -> getFormattedDateTime("MMM"));
+          put('P', () -> getFormattedDateTime("aa"));
+          put('r', () -> getFormattedDateTime("hh:mm"));
+          put('R', () -> getFormattedDateTime("HH:mm"));
+          put('s', () -> getFormattedDateTime("ss"));
+          put('w', () -> getFormattedDateTime("d"));
+          put('W', () -> getFormattedDateTime("E"));
+          put('y', () -> getFormattedDateTime("YY"));
+          put('Y', () -> getFormattedDateTime("YYYY"));
+        }}
+    );
+
+  private Prompt() {
+  }
+
+  static String getRightPrompt(SqlLine sqlLine) {
+    final int connectionIndex = sqlLine.getDatabaseConnections().getIndex();
+    final String value = sqlLine.getOpts().get(BuiltInProperty.RIGHT_PROMPT);
+    final String currentPrompt = String.valueOf((Object) null).equals(value)
+        ? (String) BuiltInProperty.RIGHT_PROMPT.defaultValue() : value;
+    return getPrompt(sqlLine, connectionIndex, currentPrompt);
+  }
+
+  static String getPrompt(SqlLine sqlLine) {
+    final String defaultPrompt =
+        String.valueOf(BuiltInProperty.PROMPT.defaultValue());
+    final String currentPrompt = sqlLine.getOpts().get(BuiltInProperty.PROMPT);
+    DatabaseConnection dbc = sqlLine.getDatabaseConnection();
+    boolean useDefaultPrompt =
+        String.valueOf((Object) null).equals(currentPrompt)
+            || Objects.equals(currentPrompt, defaultPrompt);
+    if (dbc == null || dbc.getUrl() == null) {
+      return useDefaultPrompt
+          ? getDefaultPrompt(-1, null, defaultPrompt)
+          : getPrompt(sqlLine, -1, currentPrompt);
+    } else {
+      final int connectionIndex = sqlLine.getDatabaseConnections().getIndex();
+      if (useDefaultPrompt || dbc.getNickname() != null) {
+        final String nickNameOrUrl =
+            dbc.getNickname() == null ? dbc.getUrl() : dbc.getNickname();
+        return getDefaultPrompt(connectionIndex, nickNameOrUrl, defaultPrompt);
+      } else {
+        return getPrompt(sqlLine, connectionIndex, currentPrompt);
+      }
+    }
+  }
+
+  private static String getPrompt(
+      SqlLine sqlLine, int connectionIndex, String prompt) {
+    StringBuilder promptStringBuilder = new StringBuilder();
+    final DatabaseConnection databaseConnection =
+        sqlLine.getDatabaseConnection();
+    final DatabaseMetaData databaseMetaData = databaseConnection == null
+        ? null : databaseConnection.meta;
+    final SqlLineOpts opts = sqlLine.getOpts();
+    for (int i = 0; i < prompt.length(); i++) {
+      switch (prompt.charAt(i)) {
+      case '%':
+        if (i < prompt.length() - 1) {
+          final Supplier<String> dateFormat =
+              DATE_TIME_FORMATS.get(prompt.charAt(i + 1));
+          if (dateFormat != null) {
+            promptStringBuilder.append(dateFormat.get());
+          } else {
+            switch (prompt.charAt(i + 1)) {
+            case 'c':
+              if (connectionIndex >= 0) {
+                promptStringBuilder.append(connectionIndex);
+              }
+              break;
+            case 'd':
+              if (databaseConnection != null) {
+                try {
+                  promptStringBuilder
+                      .append(databaseMetaData.getDatabaseProductName());
+                } catch (Exception e) {
+                  // skip
+                }
+              }
+              break;
+            case 'n':
+              if (databaseConnection != null) {
+                try {
+                  promptStringBuilder
+                      .append(databaseMetaData.getUserName());
+                } catch (Exception e) {
+                  // skip
+                }
+              }
+              break;
+            case 'u':
+              if (databaseConnection != null) {
+                promptStringBuilder.append(databaseConnection.getUrl());
+              }
+              break;
+            case '[':
+              if (prompt.regionMatches(
+                  i + 2, START_COLOR, 0, START_COLOR.length())) {
+                int closeBracketIndex =
+                    prompt.indexOf("%]", i + 2 + START_COLOR.length());
+                if (closeBracketIndex > 0) {
+                  String color = prompt
+                      .substring(i + 2 + START_COLOR.length(),
+                          closeBracketIndex);
+                  promptStringBuilder.append('\033').append(color);
+                  i = closeBracketIndex;
+                  break;
+                }
+              }
+            // fall through if not a color
+            case ':':
+              int nextColonIndex = prompt.indexOf(":", i + 2);
+              SqlLineProperty property;
+              if (nextColonIndex > 0
+                  && ((property = BuiltInProperty.valueOf(
+                  prompt.substring(i + 2, nextColonIndex),
+                  true)) != null)) {
+                promptStringBuilder.append(opts.get(property));
+                i = nextColonIndex - 1;
+                break;
+              }
+            // fall through if not a variable name
+            default:
+              promptStringBuilder
+                  .append(prompt.charAt(i)).append(prompt.charAt(i + 1));
+            }
+          }
+          i = i + 1;
+        }
+        break;
+      default:
+        promptStringBuilder.append(prompt.charAt(i));
+      }
+    }
+    return promptStringBuilder.toString();
+  }
+
+  private static String getDefaultPrompt(
+      int connectionIndex, String url, String defaultPrompt) {
+    String resultPrompt;
+    if (url == null || url.length() == 0) {
+      return defaultPrompt;
+    } else {
+      if (url.contains(";")) {
+        url = url.substring(0, url.indexOf(";"));
+      }
+      if (url.contains("?")) {
+        url = url.substring(0, url.indexOf("?"));
+      }
+      resultPrompt = connectionIndex + ": " + url;
+      if (resultPrompt.length() > 45) {
+        resultPrompt = resultPrompt.substring(0, 45);
+      }
+      return resultPrompt + "> ";
+    }
+  }
+
+  private static String getFormattedDateTime(final String pattern) {
+    final SimpleDateFormat sdf = new SimpleDateFormat(pattern, Locale.ROOT);
+    return sdf.format(new Date());
+  }
+}
+
+// End Prompt.java

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -536,7 +536,13 @@ public class SqlLine {
         // Execute one instruction; terminate on executing a script if
         // there is an error.
         signalHandler.setCallback(callback);
-        dispatch(reader.readLine(getPrompt()), callback);
+        dispatch(
+            reader.readLine(
+                Prompt.getPrompt(this),
+                Prompt.getRightPrompt(this),
+                (Character) null,
+                null),
+            callback);
         if (saveHistory) {
           fileHistory.save();
         }
@@ -997,37 +1003,6 @@ public class SqlLine {
     if (next != warn) {
       showWarnings(next);
     }
-  }
-
-  String getPrompt() {
-    DatabaseConnection dbc = getDatabaseConnection();
-    if (dbc == null || dbc.getUrl() == null) {
-      return "sqlline> ";
-    } else if (dbc.getNickname() != null) {
-      return getPrompt(connections.getIndex() + ": "
-          + dbc.getNickname()) + "> ";
-    } else {
-      return getPrompt(connections.getIndex() + ": " + dbc.getUrl()) + "> ";
-    }
-  }
-
-  static String getPrompt(String url) {
-    if (url == null || url.length() == 0) {
-      url = "sqlline";
-    }
-
-    if (url.contains(";")) {
-      url = url.substring(0, url.indexOf(";"));
-    }
-    if (url.contains("?")) {
-      url = url.substring(0, url.indexOf("?"));
-    }
-
-    if (url.length() > 45) {
-      url = url.substring(0, 45);
-    }
-
-    return url;
   }
 
   /**

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -738,7 +738,7 @@ public class SqlLine {
           && !line.regionMatches(1, "all", 0, "all".length())) {
         return null;
       }
-      if (!line.trim().startsWith("--") && !line.trim().startsWith("#")) {
+      if (!isComment(line)) {
         waitingPattern = ";";
       }
     }
@@ -812,10 +812,18 @@ public class SqlLine {
    * @param line the line to be tested
    * @return true if a comment
    */
+  boolean isComment(String line, boolean trim) {
+    final String trimmedLine = trim ? line.trim() : line;
+    for (String comment: getDialect().getSqlLineOneLineComments()) {
+      if (trimmedLine.startsWith(comment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   boolean isComment(String line) {
-    // SQL92 comment prefix is "--"
-    // sqlline also supports shell-style "#" prefix
-    return line.startsWith("#") || line.startsWith("--");
+    return isComment(line, true);
   }
 
   /**
@@ -1264,7 +1272,7 @@ public class SqlLine {
 
   Dialect getDialect() {
     final DatabaseConnection databaseConnection = getDatabaseConnection();
-    return databaseConnection == null
+    return databaseConnection == null || databaseConnection.getDialect() == null
         ? DialectImpl.getDefault()
         : databaseConnection.getDialect();
   }

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -620,6 +620,7 @@ public class SqlLine {
       LineReader lineReader, Widget widget, String name, CharSequence keySeq) {
     lineReader.getWidgets().put(name, widget);
     lineReader.getKeyMaps().get(LineReader.EMACS).bind(widget, keySeq);
+    lineReader.getKeyMaps().get(LineReader.VIINS).bind(widget, keySeq);
   }
 
   boolean nextColorSchemeWidget() {

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -531,6 +531,7 @@ public class SqlLine {
     // basic setup done. From this point on, honor opts value for showing
     // exception
     initComplete = true;
+    final Terminal terminal = lineReader.getTerminal();
     while (!exit) {
       try {
         // Execute one instruction; terminate on executing a script if
@@ -538,8 +539,8 @@ public class SqlLine {
         signalHandler.setCallback(callback);
         dispatch(
             reader.readLine(
-                Prompt.getPrompt(this),
-                Prompt.getRightPrompt(this),
+                Prompt.getPrompt(this).toAnsi(terminal),
+                Prompt.getRightPrompt(this).toAnsi(terminal),
                 (Character) null,
                 null),
             callback);

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -51,6 +51,8 @@ import static sqlline.BuiltInProperty.MAX_HISTORY_ROWS;
 import static sqlline.BuiltInProperty.NULL_VALUE;
 import static sqlline.BuiltInProperty.NUMBER_FORMAT;
 import static sqlline.BuiltInProperty.OUTPUT_FORMAT;
+import static sqlline.BuiltInProperty.PROMPT;
+import static sqlline.BuiltInProperty.RIGHT_PROMPT;
 import static sqlline.BuiltInProperty.ROW_LIMIT;
 import static sqlline.BuiltInProperty.SHOW_ELAPSED_TIME;
 import static sqlline.BuiltInProperty.SHOW_HEADER;
@@ -600,6 +602,14 @@ public class SqlLineOpts implements Completer {
 
   public String getOutputFormat() {
     return get(OUTPUT_FORMAT);
+  }
+
+  public String getPrompt() {
+    return get(PROMPT);
+  }
+
+  public String getRightPrompt() {
+    return get(RIGHT_PROMPT);
   }
 
   public boolean getTrimScripts() {

--- a/src/main/java/sqlline/SqlLineParser.java
+++ b/src/main/java/sqlline/SqlLineParser.java
@@ -426,7 +426,7 @@ public class SqlLineParser extends DefaultParser {
   }
 
   private String getPaddedPrompt(String waitingPattern) {
-    int length = Prompt.getPrompt(sqlLine).length();
+    int length = Prompt.getPrompt(sqlLine).columnLength();
     StringBuilder prompt = new StringBuilder(length);
     for (int i = 0; i < length - "> ".length() - waitingPattern.length(); i++) {
       prompt.append(i % 2 == 0 ? '.' : ' ');

--- a/src/main/java/sqlline/SqlLineParser.java
+++ b/src/main/java/sqlline/SqlLineParser.java
@@ -332,6 +332,7 @@ public class SqlLineParser extends DefaultParser {
   private boolean isSql(String line, ParseContext context) {
     String trimmedLine = trimLeadingSpacesIfPossible(line, context);
     return !trimmedLine.isEmpty()
+        && !sqlLine.isComment(trimmedLine, false)
         && (trimmedLine.charAt(0) != '!'
             || trimmedLine.regionMatches(0, "!sql", 0, "!sql".length())
             || trimmedLine.regionMatches(0, "!all", 0, "!all".length()));

--- a/src/main/java/sqlline/SqlLineParser.java
+++ b/src/main/java/sqlline/SqlLineParser.java
@@ -426,9 +426,9 @@ public class SqlLineParser extends DefaultParser {
   }
 
   private String getPaddedPrompt(String waitingPattern) {
-    int length = sqlLine.getPrompt().length();
-    StringBuilder prompt = new StringBuilder(length - 2);
-    for (int i = 0; i < length - 2 - waitingPattern.length(); i++) {
+    int length = Prompt.getPrompt(sqlLine).length();
+    StringBuilder prompt = new StringBuilder(length);
+    for (int i = 0; i < length - "> ".length() - waitingPattern.length(); i++) {
       prompt.append(i % 2 == 0 ? '.' : ' ');
     }
     prompt.append(waitingPattern);

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -94,6 +94,7 @@ variables:\
 \n                           to store in history file\
 \nmaxHistoryRows  integer    The maximum number of history rows \
 \n                           to store in memory\
+\nmode            emacs/vi   The editing mode \
 \nnullValue       String     Use String in place of  NULL values\
 \nnumberFormat    pattern    Format numbers using DecimalFormat pattern\
 \noutputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json\
@@ -195,6 +196,7 @@ isolation-status: Transaction isolation: {0}
 isolation-level-not-supported: Transaction isolation level {0} is not supported. Default ({1}) will be used instead.
 unknown-format: Unknown output format "{0}". Possible values: {1}
 unknown-colorscheme: Unknown color scheme "{0}". Possible values: {1}
+unknown-mode: Unknown mode "{0}". Possible values: {1}
 
 closed: closed
 open: open
@@ -279,6 +281,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --maxColumnWidth=MAXCOLWIDTH    the maximum width to use when displaying columns\n \
 \  --maxHistoryFileRows=ROWS       the maximum number of history rows to store in history file\n \
 \  --maxHistoryRows=ROWS           the maximum number of history rows to store in memory\n \
+\  --mode=[emacs/vi]               the editing mode\n \
 \  --silent=[true/false]           be more silent\n \
 \  --autosave=[true/false]         automatically save preferences\n \
 \  --outputformat=[table/vertical/csv/tsv/xmlattrs/xmlelements/json]\n \

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -98,10 +98,12 @@ variables:\
 \nnumberFormat    pattern    Format numbers using DecimalFormat pattern\
 \noutputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json\
 \n                           Format mode for result display\
+\nprompt          pattern    Format prompt\
 \npropertiesFile  path       File from which SQLLine reads properties on\
 \n                           startup; default is\
 \n                           $HOME/.sqlline/sqlline.properties (UNIX, Linux,\
 \n                           macOS), $HOME/sqlline/sqlline.properties (Windows)\
+\nrightPrompt     pattern    Format right prompt\
 \nrowLimit        integer    Maximum number of rows returned from a query; zero\
 \n                           means no limit\
 \nshowElapsedTime true/false Display execution time when verbose\

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -205,7 +205,7 @@ done: Done
 state: state
 code: code
 
-invalid-connections: Invalid connection: {0}
+invalid-connection: Invalid connection: {0}
 
 script-closed: Script closed. Enter "run {0}" to replay it.
 script-already-running: Script ({0}) is already running. Enter "script" with no arguments to stop it.

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -115,6 +115,7 @@ maxcolumnwidth
 maxHistoryFileRows
 maxHistoryRows
 maxwidth
+mode
 nullValue
 numberformat
 outputformat
@@ -246,6 +247,7 @@ maxcolumnwidth
 maxHistoryFileRows
 maxHistoryRows
 maxwidth
+mode
 nullValue
 numberformat
 outputformat
@@ -1127,6 +1129,7 @@ maxHistoryFileRows integer The maximum number of history rows
                            to store in history file
 maxHistoryRows  integer    The maximum number of history rows
                            to store in memory
+mode            emacs/vi   The editing mode
 nullValue       String     Use String in place of  NULL values
 numberFormat    pattern    Format numbers using DecimalFormat pattern
 outputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json
@@ -2078,6 +2081,7 @@ maxcolumnwidth
 maxHistoryFileRows
 maxHistoryRows
 maxwidth
+mode
 nullValue
 numberformat
 outputformat
@@ -2165,6 +2169,10 @@ The maximum number of history rows to store in memory. Defaults to 500 (org.jlin
 maxwidth
 
 The maximum width to display before truncating data when using the "table" outputformat. Defaults to attempting to query the terminal for the current width, falls back to 80.
+
+mode
+
+The editing mode to use in sqlline. Defaults to "emacs".
 
 nullvalue
 

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -118,6 +118,8 @@ maxwidth
 nullValue
 numberformat
 outputformat
+prompt
+rightprompt
 rowlimit
 showheader
 shownestederrs
@@ -247,6 +249,8 @@ maxwidth
 nullValue
 numberformat
 outputformat
+prompt
+rightprompt
 rowlimit
 showheader
 shownestederrs
@@ -1127,10 +1131,12 @@ nullValue       String     Use String in place of  NULL values
 numberFormat    pattern    Format numbers using DecimalFormat pattern
 outputFormat    table/vertical/csv/tsv/xmlattrs/xmlelements/json
                            Format mode for result display
+prompt          pattern    Format prompt
 propertiesFile  path       File from which SQLLine reads properties on
                            startup; default is
                            $HOME/.sqlline/sqlline.properties (UNIX, Linux,
                            macOS), $HOME/sqlline/sqlline.properties (Windows)
+rightPrompt     pattern    Format right prompt
 rowLimit        integer    Maximum number of rows returned from a query; zero
                            means no limit
 showElapsedTime true/false Display execution time when verbose
@@ -2075,6 +2081,8 @@ maxwidth
 nullValue
 numberformat
 outputformat
+prompt
+rightprompt
 rowlimit
 showheader
 shownestederrs
@@ -2169,6 +2177,14 @@ The format for how numeric values are displayed. Setting to default causes numer
 outputformat
 
 The format for how results are displayed. For details, see the information on the outputformat command.
+
+prompt
+
+The tcsh-like format for how prompt is displayed. For example, the setting '%[\033[1;33m%]sqlline%[\033[m%]>' yields yellow sqlline and normal angle bracket. Defaults to 'sqlline>'. If for the specific database connection nickname is set then nickname will be used.
+
+rightprompt
+
+The tcsh-like format for how right prompt is displayed. The same patterns are applied as for prompt but it does not care if nickname is set or not. Defaults to ''.
 
 rowlimit
 

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -1,0 +1,130 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test cases for prompt and right prompt.
+ */
+public class PromptTest {
+  @Test
+  public void testPromptWithoutConnection() {
+    SqlLine sqlLine = new SqlLine();
+    // default prompt
+    assertThat(Prompt.getPrompt(sqlLine),
+        is(BuiltInProperty.PROMPT.defaultValue()));
+    assertThat(Prompt.getRightPrompt(sqlLine),
+        is(BuiltInProperty.RIGHT_PROMPT.defaultValue()));
+
+    // custom constant prompt
+    final SqlLineOpts opts = sqlLine.getOpts();
+    opts.set(BuiltInProperty.PROMPT, "custom_prompt");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "custom_right_prompt");
+    assertThat(Prompt.getPrompt(sqlLine), is("custom_prompt"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("custom_right_prompt"));
+
+    // custom constant multiline prompt
+    opts.set(BuiltInProperty.PROMPT, "custom\nprompt\n");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "custom\nright\nprompt\n");
+    assertThat(Prompt.getPrompt(sqlLine), is("custom\nprompt\n"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("custom\nright\nprompt\n"));
+
+    // custom constant colored prompt
+    opts.set(BuiltInProperty.PROMPT, "%[\\033[1;33m%]sqlline>>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "%[\\033[1;30m%]end");
+    assertThat(Prompt.getPrompt(sqlLine), is("\u001B[1;33msqlline>>"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("\u001B[1;30mend"));
+
+    opts.set(BuiltInProperty.PROMPT, "%[\\033[1;33m%]sqlline%[\\033[m%]>>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "[%[\\033[1;30m%]end%[\\033[m%]]");
+    assertThat(Prompt.getPrompt(sqlLine), is("\u001B[1;33msqlline\u001B[m>>"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("[\u001B[1;30mend\u001B[m]"));
+
+    // custom prompt with date values
+    opts.set(BuiltInProperty.PROMPT, "%w_%W_%o_%O_%y_%Y>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "[%w_%W_%o_%O_%y_%Y]");
+    final SimpleDateFormat sdf =
+        new SimpleDateFormat("d_E_MM_MMM_YY_YYYY", Locale.ROOT);
+    assertThat(Prompt.getPrompt(sqlLine), is(sdf.format(new Date()) + ">"));
+    assertThat(Prompt.getRightPrompt(sqlLine),
+        is("[" + sdf.format(new Date()) + "]"));
+
+    // custom prompt with data from connection (empty if there is no connection)
+    opts.set(BuiltInProperty.PROMPT, "%u%n");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "%d%c");
+    assertThat(Prompt.getPrompt(sqlLine), is(""));
+    assertThat(Prompt.getRightPrompt(sqlLine), is(""));
+
+    opts.set(BuiltInProperty.PROMPT, "%u%c>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "<<<%n%d");
+    assertThat(Prompt.getPrompt(sqlLine), is(">"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("<<<"));
+
+    // custom prompt with property value
+    opts.set(BuiltInProperty.PROMPT, "%:color:>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "%:outputformat:");
+    assertThat(Prompt.getPrompt(sqlLine), is(opts.getColor() + ">"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is(opts.getOutputFormat()));
+  }
+
+  @Test
+  public void testPromptWithNickname() {
+    SqlLine sqlLine = new SqlLine();
+    DispatchCallback dc = new DispatchCallback();
+    sqlLine.runCommands(
+        Collections.singletonList("!connect "
+            + SqlLineArgsTest.ConnectionSpec.H2.url + " "
+            + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
+        dc);
+
+    // custom prompt with data from connection
+    final SqlLineOpts opts = sqlLine.getOpts();
+    sqlLine.getDatabaseConnection().setNickname("nickname");
+    opts.set(BuiltInProperty.PROMPT, "%u@%n>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "//%d%c");
+    // if nickname is specified for the connection
+    // it has more priority than prompt.
+    // Right prompt does not care about nickname
+    assertThat(Prompt.getPrompt(sqlLine), is("0: nickname> "));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("//H20"));
+  }
+
+  @Test
+  public void testPromptWithConnection() {
+    SqlLine sqlLine = new SqlLine();
+    DispatchCallback dc = new DispatchCallback();
+    sqlLine.runCommands(
+        Collections.singletonList("!connect "
+            + SqlLineArgsTest.ConnectionSpec.H2.url + " "
+            + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
+        dc);
+
+    // custom prompt with data from connection
+    final SqlLineOpts opts = sqlLine.getOpts();
+    opts.set(BuiltInProperty.PROMPT, "%u@%n>");
+    opts.set(BuiltInProperty.RIGHT_PROMPT, "//%d%c");
+    assertThat(Prompt.getPrompt(sqlLine), is("jdbc:h2:mem:@SA>"));
+    assertThat(Prompt.getRightPrompt(sqlLine), is("//H20"));
+    sqlLine.getDatabaseConnection().close();
+  }
+}
+
+// End PromptTest.java

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -31,6 +31,7 @@ import org.hsqldb.jdbc.JDBCDatabaseMetaData;
 import org.hsqldb.jdbc.JDBCResultSet;
 import org.hsqldb.jdbc.JDBCResultSetMetaData;
 import org.jline.builtins.Commands;
+import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -1970,6 +1971,32 @@ public class SqlLineArgsTest {
           containsString(
               sqlLine.loc("unknown-colorscheme", invalidColorScheme,
                   new TreeSet<>(BuiltInHighlightStyle.BY_NAME.keySet()))));
+      os.reset();
+    } catch (Exception e) {
+      // fail
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testSetWrongEditingMode() {
+    final SqlLine sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    try {
+      SqlLine.Status status = begin(sqlLine, os, false);
+      // Here the status is SqlLine.Status.OTHER
+      // because of EOF as the result of InputStream which
+      // is not used in the current test so it is ok
+      assertThat(status, equalTo(SqlLine.Status.OTHER));
+      DispatchCallback dc = new DispatchCallback();
+      final String invalidEditingMode = "invalid";
+      sqlLine.runCommands(
+          Collections.singletonList(
+              "!set mode " + invalidEditingMode), dc);
+      assertThat(os.toString("UTF8"),
+          containsString(
+              sqlLine.loc("unknown-mode", invalidEditingMode,
+                  Arrays.asList(LineReader.EMACS, "vi"))));
       os.reset();
     } catch (Exception e) {
       // fail

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -443,6 +443,21 @@ public class SqlLineArgsTest {
   }
 
   /**
+   * Test !go <non-existent connection indexes>.
+   */
+  @Test
+  public void testGoFailing() {
+    final String[] connectionIndexes = {"321", "invalid"};
+    for (String connectionIndex : connectionIndexes) {
+      final String script = "!go " + connectionIndex + "\n";
+      final String expected = "Invalid connection: " + connectionIndex;
+      checkScriptFile(script, false,
+          // Status.OTHER as checking of fail cases
+          equalTo(SqlLine.Status.OTHER), containsString(expected));
+    }
+  }
+
+  /**
    * Tests "!help go". "go" and "#" are synonyms.
    */
   @Test

--- a/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
@@ -153,7 +153,7 @@ public class SqlLineHighlighterLowLevelTest {
 
   /**
    * Low level test of
-   * {@link SqlLineHighlighter#handleComments(String, BitSet, int)}.
+   * {@link SqlLineHighlighter#handleComments(String, BitSet, int, boolean)}.
    *
    * <p>WARNING: Change this test only if you know what you are doing.
    * Otherwise put your test into
@@ -176,7 +176,7 @@ public class SqlLineHighlighterLowLevelTest {
           new ExpectedHighlightStyle(line.length());
       expectedStyle.comments.set(0, line.length());
       BitSet actual = new BitSet(line.length());
-      defaultHighlighter.handleComments(line, actual, 0);
+      defaultHighlighter.handleComments(line, actual, 0, true);
       assertEquals("Line [" + line + "]", expectedStyle.comments, actual);
     }
   }

--- a/src/test/java/sqlline/SqlLineParserTest.java
+++ b/src/test/java/sqlline/SqlLineParserTest.java
@@ -169,6 +169,22 @@ public class SqlLineParserTest {
   }
 
   @Test
+  public void testSqlLineParserForWrongLinesWithEmptyPrompt() {
+    SqlLine sqlLine = new SqlLine();
+    sqlLine.getOpts().set(BuiltInProperty.PROMPT, "");
+    final DefaultParser parser = new SqlLineParser(sqlLine);
+    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
+    for (String line : WRONG_LINES) {
+      try {
+        parser.parse(line, line.length(), acceptLine);
+        Assert.fail("Missing closing quote or semicolon for line " + line);
+      } catch (EOFError eofError) {
+        //ok
+      }
+    }
+  }
+
+  @Test
   public void testSqlLineParserOfWrongLinesForSwitchedOfflineContinuation() {
     final SqlLine sqlLine = new SqlLine();
     sqlLine.getOpts().set(BuiltInProperty.USE_LINE_CONTINUATION, false);


### PR DESCRIPTION
The PR adds the `mode` property to allow manual switch between `emacs` (default) and `vi` mode. 