### PR TITLE
[SQLLINE-207] Escape angle brackets to have valid HTML, add @param de…

### DIFF
--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -444,7 +444,7 @@ public class SqlLineArgsTest {
   }
 
   /**
-   * Test !go <non-existent connection indexes>.
+   * Test !go &lt;non-existent connection indexes&gt;.
    */
   @Test
   public void testGoFailing() {
@@ -1183,6 +1183,8 @@ public class SqlLineArgsTest {
    * The bug in question is
    * <a href="https://issues.apache.org/jira/browse/HIVE-20938">[HIVE-20983]
    * HiveResultSetMetaData.getColumnDisplaySize throws for SHORT column</a>.
+   *
+   * @param meta mocked JDBCResultSetMetaData to use in the test
    */
   @Test
   public void testOutputWithFailingColumnDisplaySize(


### PR DESCRIPTION
The PR escapes angle brackets in javadoc and adds `@param` description to failure of `mvn javadoc:javadoc` call