### PR TITLE
[SQLLINE-215] Use getDeclaredMethods for possible metadata values

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -14,6 +14,7 @@ package sqlline;
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.*;
@@ -187,6 +188,9 @@ public class Commands {
       Set<String> methodNames = new TreeSet<>();
       Set<String> methodNamesUpper = new TreeSet<>();
       for (Method method : methods) {
+        if (!Modifier.isPublic(method.getModifiers())) {
+          continue;
+        }
         methodNames.add(method.getName());
         methodNamesUpper.add(method.getName().toUpperCase(Locale.ROOT));
       }

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -182,7 +182,8 @@ public class Commands {
     }
 
     try {
-      Method[] methods = sqlLine.getDatabaseMetaData().getClass().getMethods();
+      Method[] methods =
+          sqlLine.getDatabaseMetaData().getClass().getDeclaredMethods();
       Set<String> methodNames = new TreeSet<>();
       Set<String> methodNamesUpper = new TreeSet<>();
       for (Method method : methods) {

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1546,6 +1546,19 @@ public class SqlLineArgsTest {
   }
 
   @Test
+  public void testPossibleMetadataValues() {
+    final String script = "!metadata 1\n";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OTHER),
+        allOf(not(containsString("Exception")),
+            not(containsString("equals")),
+            not(containsString("notify")),
+            not(containsString("wait")),
+            not(containsString("toString")),
+            not(containsString("hashCode")),
+            not(containsString("notifyAll"))));
+  }
+
+  @Test
   public void testEmptyRecord() {
     final String line = "Usage: record <file name>";
     checkScriptFile("!record", true, equalTo(SqlLine.Status.OTHER),


### PR DESCRIPTION
The PR uses `getDeclaredMethods` to get possible arguments for `!metadata`.

fixes #215 