### PR TITLE
[SQLLINE-217] Enable jdk11 for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
   - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   - JAVA_HOME: C:\Program Files\Java\jdk9
   - JAVA_HOME: C:\Program Files\Java\jdk10
+  - JAVA_HOME: C:\Program Files\Java\jdk11
 build_script:
 - mvn clean -V install -DskipTests -Dmaven.javadoc.skip=true -Djavax.net.ssl.trustStorePassword=changeit
 test_script:


### PR DESCRIPTION
The PR enables jdk11 build for Appveyor CI.

fixes #217 