### PR TITLE
[SQLLINE-221] Set minimum jdk to 1.8 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Use the following definition to use `sqlline` in your maven project:
 Prerequisites:
 
 * Maven 3.2.5 or higher
-* Java 1.6 or higher (10 preferred)
+* Java 1.8 or higher (10 preferred)
 
 Check out and build:
 

--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -32,7 +32,7 @@
       <filename>sqlplus</filename> for Oracle, <filename>mysql</filename>
       for MySQL, and <filename>isql</filename> for Sybase/SQL Server.
       Since it is pure Java, it is platform independent, and will
-      run on any platform that can run Java 1.6 or higher.
+      run on any platform that can run Java 1.8 or higher.
       </para>
     </chapter>
 
@@ -74,7 +74,7 @@
             <listitem><para>
             <trademark>Java</trademark> Virtual Machine -
             SQLLine is a pure
-            java program, and requires Java version 1.6 or higher
+            java program, and requires Java version 1.8 or higher
             in order to run. The latest JVM can be downloaded from
             <ulink url="http://java.sun.com"/>.
             </para></listitem>


### PR DESCRIPTION
The PR corrects minimum jdk version in docs

fixes #221 