### PR TITLE
[SQLLINE-134] Reuse history object while resetting history, use -e op…

### DIFF
--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -467,8 +467,10 @@ public class SqlLineOpts implements Completer {
       propertiesMap.put(HISTORY_FILE, Commands.expand(historyFile));
     }
     if (sqlLine != null && sqlLine.getLineReader() != null) {
-      final History history = sqlLine.getLineReader().getHistory();
-      if (history != null) {
+      History history = sqlLine.getLineReader().getHistory();
+      if (history == null) {
+        history = new DefaultHistory();
+      } else {
         try {
           history.save();
         } catch (IOException e) {
@@ -477,7 +479,7 @@ public class SqlLineOpts implements Completer {
       }
       sqlLine.getLineReader()
           .setVariable(LineReader.HISTORY_FILE, get(HISTORY_FILE));
-      new DefaultHistory().attach(sqlLine.getLineReader());
+      history.attach(sqlLine.getLineReader());
     }
   }
 

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -11,6 +11,7 @@
 */
 package sqlline;
 
+import java.io.ByteArrayOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -23,6 +24,8 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import static sqlline.SqlLineArgsTest.begin;
 
 /**
  * Test cases for prompt and right prompt.
@@ -114,43 +117,59 @@ public class PromptTest {
 
   @Test
   public void testPromptWithNickname() {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
     SqlLine sqlLine = new SqlLine();
-    DispatchCallback dc = new DispatchCallback();
-    sqlLine.runCommands(
-        Collections.singletonList("!connect "
-            + SqlLineArgsTest.ConnectionSpec.H2.url + " "
-            + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
-        dc);
+    try {
+      SqlLine.Status status = begin(
+          sqlLine, os, false, "-e", "!set maxwidth 80");
+      final DispatchCallback dc = new DispatchCallback();
+      sqlLine.runCommands(
+          Collections.singletonList("!connect "
+              + SqlLineArgsTest.ConnectionSpec.H2.url + " "
+              + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
+          dc);
 
-    // custom prompt with data from connection
-    final SqlLineOpts opts = sqlLine.getOpts();
-    sqlLine.getDatabaseConnection().setNickname("nickname");
-    opts.set(BuiltInProperty.PROMPT, "%u@%n>");
-    opts.set(BuiltInProperty.RIGHT_PROMPT, "//%d%c");
-    // if nickname is specified for the connection
-    // it has more priority than prompt.
-    // Right prompt does not care about nickname
-    assertThat(Prompt.getPrompt(sqlLine).toAnsi(), is("0: nickname> "));
-    assertThat(Prompt.getRightPrompt(sqlLine).toAnsi(), is("//H20"));
+      // custom prompt with data from connection
+      final SqlLineOpts opts = sqlLine.getOpts();
+      sqlLine.getDatabaseConnection().setNickname("nickname");
+      opts.set(BuiltInProperty.PROMPT, "%u@%n>");
+      opts.set(BuiltInProperty.RIGHT_PROMPT, "//%d%c");
+      // if nickname is specified for the connection
+      // it has more priority than prompt.
+      // Right prompt does not care about nickname
+      assertThat(Prompt.getPrompt(sqlLine).toAnsi(), is("0: nickname> "));
+      assertThat(Prompt.getRightPrompt(sqlLine).toAnsi(), is("//H20"));
+    } catch (Exception e) {
+      // fail
+      throw new RuntimeException(e);
+    }
   }
 
   @Test
   public void testPromptWithConnection() {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
     SqlLine sqlLine = new SqlLine();
-    DispatchCallback dc = new DispatchCallback();
-    sqlLine.runCommands(
-        Collections.singletonList("!connect "
-            + SqlLineArgsTest.ConnectionSpec.H2.url + " "
-            + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
-        dc);
+    try {
+      SqlLine.Status status = begin(
+          sqlLine, os, false, "-e", "!set maxwidth 80");
+      final DispatchCallback dc = new DispatchCallback();
+      sqlLine.runCommands(
+          Collections.singletonList("!connect "
+              + SqlLineArgsTest.ConnectionSpec.H2.url + " "
+              + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\""),
+          dc);
 
-    // custom prompt with data from connection
-    final SqlLineOpts opts = sqlLine.getOpts();
-    opts.set(BuiltInProperty.PROMPT, "%u@%n>");
-    opts.set(BuiltInProperty.RIGHT_PROMPT, "//%d%c");
-    assertThat(Prompt.getPrompt(sqlLine).toAnsi(), is("jdbc:h2:mem:@SA>"));
-    assertThat(Prompt.getRightPrompt(sqlLine).toAnsi(), is("//H20"));
-    sqlLine.getDatabaseConnection().close();
+      // custom prompt with data from connection
+      final SqlLineOpts opts = sqlLine.getOpts();
+      opts.set(BuiltInProperty.PROMPT, "%u@%n>");
+      opts.set(BuiltInProperty.RIGHT_PROMPT, "//%d%c");
+      assertThat(Prompt.getPrompt(sqlLine).toAnsi(), is("jdbc:h2:mem:@SA>"));
+      assertThat(Prompt.getRightPrompt(sqlLine).toAnsi(), is("//H20"));
+      sqlLine.getDatabaseConnection().close();
+    } catch (Exception e) {
+      // fail
+      throw new RuntimeException(e);
+    }
   }
 }
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -62,7 +62,7 @@ public class SqlLineArgsTest {
     connectionSpec = CONNECTION_SPEC;
   }
 
-  private static SqlLine.Status begin(
+  static SqlLine.Status begin(
       SqlLine sqlLine, OutputStream os, boolean saveHistory, String... args) {
     try {
       PrintStream beelineOutputStream = getPrintStream(os);
@@ -508,17 +508,13 @@ public class SqlLineArgsTest {
                   PrintStream err,
                   Path currentDir,
                   String[] argv) {
-          return;
         }
       };
 
       SqlLine beeLine = new SqlLine();
       SqlLine.Status status =
-          begin(beeLine, baos, false);
-      // Here it is the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      // assertThat(status, equalTo(SqlLine.Status.OK));
+          begin(beeLine, baos, false, "-e", "!set maxwidth 80");
+      assertThat(status, equalTo(SqlLine.Status.OK));
       beeLine.runCommands(Collections.singletonList("!manual"),
           new DispatchCallback());
       String output = baos.toString("UTF8");
@@ -1642,11 +1638,8 @@ public class SqlLineArgsTest {
 
   @Test
   public void testAppInfoMessage() {
-    Pair pair = run();
-    // Here it is the status is SqlLine.Status.OTHER
-    // because of EOF as the result of InputStream which
-    // is not used in the current test so it is ok
-    // assertThat(status, equalTo(SqlLine.Status.OK));
+    Pair pair = run("-e", "!set maxwidth 80");
+    assertThat(pair.status, equalTo(SqlLine.Status.OK));
     assertThat(pair.output,
         containsString(Application.DEFAULT_APP_INFO_MESSAGE));
 
@@ -1803,13 +1796,10 @@ public class SqlLineArgsTest {
       bw.flush();
 
       SqlLine.Status status = begin(beeLine, os, true,
-          "--historyfile=" + tmpHistoryFile.getAbsolutePath());
-      // Here the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      assertThat(status, equalTo(SqlLine.Status.OTHER));
+          "--historyfile=" + tmpHistoryFile.getAbsolutePath(),
+          "-e", "!set maxwidth 80");
+      assertThat(status, equalTo(SqlLine.Status.OK));
       DispatchCallback dc = new DispatchCallback();
-      beeLine.runCommands(Collections.singletonList("!set maxwidth 80"), dc);
       beeLine.runCommands(
           Collections.singletonList("!set maxcolumnwidth 30"), dc);
       beeLine.runCommands(
@@ -1988,11 +1978,9 @@ public class SqlLineArgsTest {
       bw.close();
 
       SqlLine.Status status = begin(beeLine, os, true,
-          "--historyfile=" + tmpHistoryFile.getAbsolutePath());
-      // Here the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      assertThat(status, equalTo(SqlLine.Status.OTHER));
+          "--historyfile=" + tmpHistoryFile.getAbsolutePath(),
+          "-e", "!set maxwidth 80");
+      assertThat(status, equalTo(SqlLine.Status.OK));
       DispatchCallback dc = new DispatchCallback();
 
       final int maxLines = 3;
@@ -2015,15 +2003,11 @@ public class SqlLineArgsTest {
     final SqlLine beeLine = new SqlLine();
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     try {
-      SqlLine.Status status = begin(beeLine, os, false);
-      // Here the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      assertThat(status, equalTo(SqlLine.Status.OTHER));
-      DispatchCallback dc = new DispatchCallback();
+      SqlLine.Status status = begin(beeLine, os, false,
+          "-e", "!save");
+      assertThat(status, equalTo(SqlLine.Status.OK));
+      final DispatchCallback dc = new DispatchCallback();
 
-      beeLine.runCommands(
-          Collections.singletonList("!save"), dc);
       assertThat(os.toString("UTF8"),
           containsString("Saving preferences to"));
       os.reset();
@@ -2044,12 +2028,10 @@ public class SqlLineArgsTest {
     final SqlLine sqlLine = new SqlLine();
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     try {
-      SqlLine.Status status = begin(sqlLine, os, false);
-      // Here the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      assertThat(status, equalTo(SqlLine.Status.OTHER));
-      DispatchCallback dc = new DispatchCallback();
+      SqlLine.Status status = begin(
+          sqlLine, os, false, "-e", "!set maxwidth 80");
+      assertThat(status, equalTo(SqlLine.Status.OK));
+      final DispatchCallback dc = new DispatchCallback();
       final String invalidColorScheme = "invalid";
       sqlLine.runCommands(
           Collections.singletonList(
@@ -2070,11 +2052,9 @@ public class SqlLineArgsTest {
     final SqlLine sqlLine = new SqlLine();
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     try {
-      SqlLine.Status status = begin(sqlLine, os, false);
-      // Here the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      assertThat(status, equalTo(SqlLine.Status.OTHER));
+      SqlLine.Status status = begin(
+          sqlLine, os, false, "-e", "!set maxwidth 80");
+      assertThat(status, equalTo(SqlLine.Status.OK));
       DispatchCallback dc = new DispatchCallback();
       final String invalidEditingMode = "invalid";
       sqlLine.runCommands(


### PR DESCRIPTION
The PR makes reuse of history object while resetting history that allows to use `-e` option for `testRerun`.
Also it makes usage of `-e` option everywhere to hide output.

fixes #134 