### PR TITLE
[SQLLINE-5] Use ServiceLoader to load drivers rather than forName

### DIFF
--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.jline.builtins.Completers.FileNameCompleter;
@@ -47,72 +46,6 @@ import org.jline.reader.impl.completer.StringsCompleter;
 public class Application {
 
   public static final String DEFAULT_APP_INFO_MESSAGE = "sqlline version ???";
-
-  private static final String[] DRIVERS = {
-      "centura.java.sqlbase.SqlbaseDriver",
-      "com.amazonaws.athena.jdbc.AthenaDriver",
-      "COM.cloudscape.core.JDBCDriver",
-      "com.ddtek.jdbc.db2.DB2Driver",
-      "com.ddtek.jdbc.informix.InformixDriver",
-      "com.ddtek.jdbc.oracle.OracleDriver",
-      "com.ddtek.jdbc.sqlserver.SQLServerDriver",
-      "com.ddtek.jdbc.sybase.SybaseDriver",
-      "COM.FirstSQL.Dbcp.DbcpDriver",
-      "com.ibm.as400.access.AS400JDBCDriver",
-      "com.ibm.db2.jcc.DB2Driver",
-      "COM.ibm.db2.jdbc.app.DB2Driver",
-      "COM.ibm.db2.jdbc.net.DB2Driver",
-      "com.imaginary.sql.msql.MsqlDriver",
-      "com.inet.tds.TdsDriver",
-      "com.informix.jdbc.IfxDriver",
-      "com.internetcds.jdbc.tds.Driver",
-      "com.internetcds.jdbc.tds.SybaseDriver",
-      "com.jnetdirect.jsql.JSQLDriver",
-      "com.lucidera.jdbc.LucidDbRmiDriver",
-      "com.mckoi.JDBCDriver",
-      "com.merant.datadirect.jdbc.db2.DB2Driver",
-      "com.merant.datadirect.jdbc.informix.InformixDriver",
-      "com.merant.datadirect.jdbc.oracle.OracleDriver",
-      "com.merant.datadirect.jdbc.sqlserver.SQLServerDriver",
-      "com.merant.datadirect.jdbc.sybase.SybaseDriver",
-      "com.microsoft.jdbc.sqlserver.SQLServerDriver",
-      "com.mysql.jdbc.DatabaseMetaData",
-      "com.mysql.jdbc.Driver",
-      "com.mysql.jdbc.NonRegisteringDriver",
-      "com.pointbase.jdbc.jdbcDriver",
-      "com.pointbase.jdbc.jdbcEmbeddedDriver",
-      "com.pointbase.jdbc.jdbcUniversalDriver",
-      "com.sap.dbtech.jdbc.DriverSapDB",
-      "com.sqlstream.jdbc.Driver",
-      "com.sybase.jdbc2.jdbc.SybDriver",
-      "com.sybase.jdbc.SybDriver",
-      "com.thinweb.tds.Driver",
-      "in.co.daffodil.db.jdbc.DaffodilDBDriver",
-      "interbase.interclient.Driver",
-      "intersolv.jdbc.sequelink.SequeLinkDriver",
-      "net.sourceforge.jtds.jdbc.Driver",
-      "openlink.jdbc2.Driver",
-      "oracle.jdbc.driver.OracleDriver",
-      "oracle.jdbc.OracleDriver",
-      "oracle.jdbc.pool.OracleDataSource",
-      "org.axiondb.jdbc.AxionDriver",
-      "org.enhydra.instantdb.jdbc.idbDriver",
-      "org.gjt.mm.mysql.Driver",
-      "org.hsqldb.jdbcDriver",
-      "org.hsql.jdbcDriver",
-      "org.luciddb.jdbc.LucidDbClientDriver",
-      "org.postgresql.Driver",
-      "org.sourceforge.jxdbcon.JXDBConDriver",
-      "postgres95.PGDriver",
-      "postgresql.Driver",
-      "solid.jdbc.SolidDriver",
-      "sun.jdbc.odbc.JdbcOdbcDriver",
-      "weblogic.jdbc.mssqlserver4.Driver",
-      "weblogic.jdbc.pool.Driver",
-  };
-
-  private static final SortedSet<String> DEFAULT_DRIVERS =
-      Collections.unmodifiableSortedSet(new TreeSet<>(Arrays.asList(DRIVERS)));
 
   private static final String[] CONNECTION_URLS = {
       "jdbc:JSQLConnect://<hostname>/database=<database>",
@@ -192,18 +125,21 @@ public class Application {
   }
 
   /**
-   * Deprecated as META-INF/services/java.sql.Driver is used instead
-   * Returns the set of known JDBC drivers.
+   * Returns the set of allowed JDBC drivers.
    *
-   * <p>Override this method to modify set of supported known drivers.
+   * <p>Override this method to modify set of allowed drivers.
    *
-   * @return Collection of known drivers
-   *
-   * @see #DEFAULT_DRIVERS
+   * @return Collection of allowed drivers, empty if any is allowed
    */
-  @Deprecated
-  public Collection<String> initDrivers() {
-    return DEFAULT_DRIVERS;
+  public Collection<String> allowedDrivers() {
+    return Collections.emptyList();
+  }
+
+  /**
+   * Deprecated, use {@link Application#allowedDrivers} instead
+   */
+  @Deprecated public Collection<String> initDrivers() {
+    return allowedDrivers();
   }
 
   /**

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -192,6 +192,7 @@ public class Application {
   }
 
   /**
+   * Deprecated as META-INF/services/java.sql.Driver is used instead
    * Returns the set of known JDBC drivers.
    *
    * <p>Override this method to modify set of supported known drivers.
@@ -200,6 +201,7 @@ public class Application {
    *
    * @see #DEFAULT_DRIVERS
    */
+  @Deprecated
   public Collection<String> initDrivers() {
     return DEFAULT_DRIVERS;
   }

--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -125,14 +125,14 @@ public class Application {
   }
 
   /**
-   * Returns the set of allowed JDBC drivers.
+   * Returns the list of allowed JDBC drivers.
    *
-   * <p>Override this method to modify set of allowed drivers.
+   * <p>Override this method to modify list of allowed drivers.
    *
-   * @return Collection of allowed drivers, empty if any is allowed
+   * @return List of allowed drivers, null if any is allowed
    */
-  public Collection<String> allowedDrivers() {
-    return Collections.emptyList();
+  public List<String> allowedDrivers() {
+    return null;
   }
 
   /**

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -502,7 +502,7 @@ public class Commands {
     TreeMap<String, Driver> driverNames = new TreeMap<>();
 
     if (sqlLine.getDrivers() == null) {
-      sqlLine.setDrivers(sqlLine.scanDrivers(line));
+      sqlLine.setDrivers(sqlLine.scanDrivers());
     }
 
     sqlLine.info(

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -498,9 +498,8 @@ public class Commands {
     callback.setToSuccess();
   }
 
-  public void scan(String line, DispatchCallback callback)
-      throws IOException {
-    TreeSet<String> names = new TreeSet<>();
+  public void scan(String line, DispatchCallback callback) {
+    TreeMap<String, Driver> driverNames = new TreeMap<>();
 
     if (sqlLine.getDrivers() == null) {
       sqlLine.setDrivers(sqlLine.scanDrivers(line));
@@ -510,8 +509,9 @@ public class Commands {
         sqlLine.loc("drivers-found-count", sqlLine.getDrivers().size()));
 
     // unique the list
+
     for (Driver driver : sqlLine.getDrivers()) {
-      names.add(driver.getClass().getName());
+      driverNames.put(driver.getClass().getName(), driver);
     }
 
     String compliant =
@@ -525,10 +525,10 @@ public class Commands {
         .bold(jdbcVersion)
         .bold(driverClass));
 
-    for (String name : names) {
+    for (Map.Entry<String, Driver> driverEntry : driverNames.entrySet()) {
+      final Driver driver = driverEntry.getValue();
+      final String name = driverEntry.getKey();
       try {
-        final Class<?> klass = Class.forName(name);
-        Driver driver = (Driver) klass.getConstructor().newInstance();
         ColorBuffer msg = sqlLine.getColorBuffer()
             .pad(driver.jdbcCompliant() ? "yes" : "no", 10)
             .pad(driver.getMajorVersion() + "."

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1706,6 +1706,56 @@ public class SqlLineArgsTest {
   }
 
   @Test
+  public void testScanForEmptyAllowedDrivers() {
+    new MockUp<CustomApplication>() {
+      @Mock
+      public List<String> allowedDrivers() {
+        return Collections.emptyList();
+      }
+    };
+
+    final String script = "!appconfig"
+        + " sqlline.extensions.CustomApplication\n"
+        + "!scan";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        containsString("No driver classes found"));
+  }
+
+  @Test
+  public void testScanForOnlyH2Allowed() {
+    new MockUp<CustomApplication>() {
+      @Mock
+      public List<String> allowedDrivers() {
+        return Collections.singletonList("org.h2.Driver");
+      }
+    };
+
+    final String script = "!appconfig"
+        + " sqlline.extensions.CustomApplication\n"
+        + "!scan";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        allOf(containsString("yes       1.4     org.h2.Driver"),
+                not(containsString("org.hsqldb.jdbc.JDBCDriver"))));
+  }
+
+  @Test
+  public void testScanForOnlyHsqldbAllowed() {
+    new MockUp<CustomApplication>() {
+      @Mock
+      public List<String> allowedDrivers() {
+        return Collections.singletonList("org.hsqldb.jdbc.JDBCDriver");
+      }
+    };
+
+    final String script = "!appconfig"
+        + " sqlline.extensions.CustomApplication\n"
+        + "!scan";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        allOf(containsString("yes       2.4     org.hsqldb.jdbc.JDBCDriver"),
+            not(containsString("org.h2.Driver"))));
+  }
+
+  @Test
   public void testVersion() {
     final String script = "!set\n";
     try {

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -326,8 +326,8 @@ public class SqlLineArgsTest {
 
   @Test
   public void testScan() {
-    final String expectedLine0 = "Compliant Version Driver Class\n";
-    final String expectedLine1 = "yes       2.4     org.hsqldb.jdbcDriver";
+    final String expectedLine0 = "Compliant Version Driver Class";
+    final String expectedLine1 = "yes       2.4     org.hsqldb.jdbc.JDBCDriver";
     checkScriptFile("!scan\n", false,
         equalTo(SqlLine.Status.OK),
         allOf(containsString(expectedLine0), containsString(expectedLine1)));


### PR DESCRIPTION
The PR implements usage of drivers mentioned by `META-INF/services/java.sql.Driver`

Also it allows to see errors in case of drivers loading which is impossible for current version.

Checked with latest drivers
- mysql
- oracle
- avatica
- calcite
- phoenix

fixes #5 