### PR TITLE
Add error message for absent url but presented one of user, password,…

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1203,7 +1203,7 @@ public class Commands {
 
     if (url == null || url.length() == 0) {
       callback.setToFailure();
-      sqlLine.error("Property \"url\" is required");
+      sqlLine.error(sqlLine.loc("no-url"));
       return;
     }
     if (driver == null || driver.length() == 0) {

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -405,10 +405,10 @@ public class SqlLine {
           new DispatchCallback());
     }
 
-    if (url != null) {
+    if (url != null || user != null || pass != null || driver != null) {
       String com =
           COMMAND_PREFIX + "connect "
-              + url + " "
+              + (url == null ? "\"\"" : url) + " "
               + (user == null || user.length() == 0 ? "''" : user) + " "
               + (pass == null || pass.length() == 0 ? "''" : pass) + " "
               + (driver == null ? "" : driver);

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -21,6 +21,7 @@ no-specified-driver: Could not find driver {0}
 no-specified-driver-use-existing: Could not find driver {0}; using registered driver {1} instead
 no-specified-prop: Specified property [{0}] does not exist. \
   Use !set command to get list of all available properties.
+no-url: Property "url" is required
 reset-all-props: All properties were reset to their defaults.
 reset-prop: [{0}] was reset to [{1}]
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -2091,6 +2091,32 @@ public class SqlLineArgsTest {
     }
   }
 
+  @Test
+  public void testStartupArgsWithoutUrl() {
+    try {
+      SqlLine sqlLine = new SqlLine();
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      PrintStream sqllineOutputStream =
+          new PrintStream(os, false, StandardCharsets.UTF_8.name());
+      sqlLine.setOutputStream(sqllineOutputStream);
+      sqlLine.setErrorStream(sqllineOutputStream);
+      String[] args = {
+          "-d",
+          "org.hsqldb.jdbcDriver",
+          "-n",
+          "SCOTT",
+          "-p",
+          "TIGER"
+      };
+      DispatchCallback callback = new DispatchCallback();
+      sqlLine.initArgs(args, callback);
+      assertThat(os.toString("UTF8"), containsString(sqlLine.loc("no-url")));
+    } catch (Throwable e) {
+      // fail
+      throw new RuntimeException(e);
+    }
+  }
+
   /** Information necessary to create a JDBC connection. Specify one to run
    * tests against a different database. (hsqldb is the default.) */
   public static class ConnectionSpec {


### PR DESCRIPTION
The PR makes showing error messages in case of absent/empty url but with presented user/password/driver properties.

fixes issue mentioned in the comment https://github.com/julianhyde/sqlline/issues/5#issuecomment-388011824