### PR TITLE
[SQLLINE-252] Update jmockit to 1.44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
             <user.language>TR</user.language>
             <user.country>tr</user.country>
           </systemPropertyVariables>
-          <argLine>-Xmx1024m -javaagent:${org.jmockit:jmockit:jar}</argLine>
+          <argLine>-Xmx1024m -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <h2.version>1.4.197</h2.version>
     <hsqldb.version>2.4.1</hsqldb.version>
     <jline.version>3.9.0</jline.version>
-    <jmockit.version>1.41</jmockit.version>
+    <jmockit.version>1.44</jmockit.version>
     <junit.version>4.12</junit.version>
     <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
@@ -43,6 +43,7 @@
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-javadoc-plugin.additionalOptions>-html5</maven-javadoc-plugin.additionalOptions>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
     <scott-data-hsqldb.version>0.1</scott-data-hsqldb.version>
   </properties>
 
@@ -259,6 +260,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <useManifestOnlyJar>false</useManifestOnlyJar>
           <systemPropertyVariables>

--- a/src/test/java/sqlline/DatabaseMetaDataWrapperTest.java
+++ b/src/test/java/sqlline/DatabaseMetaDataWrapperTest.java
@@ -16,11 +16,9 @@ import java.sql.SQLFeatureNotSupportedException;
 
 import org.hsqldb.jdbc.JDBCDatabaseMetaData;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import mockit.Expectations;
 import mockit.Mocked;
-import mockit.integration.junit4.JMockit;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -28,7 +26,6 @@ import static org.junit.Assert.assertThat;
 /**
  * Test cases for not supported {@link java.sql.DatabaseMetaData} methods.
  */
-@RunWith(JMockit.class)
 public class DatabaseMetaDataWrapperTest {
 
   @Test

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -36,14 +36,12 @@ import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
 
-import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-import mockit.integration.junit4.JMockit;
+import mockit.internal.reflection.FieldReflection;
 import net.hydromatic.scott.data.hsqldb.ScottHsqldb;
 import sqlline.extensions.CustomApplication;
 
@@ -53,7 +51,6 @@ import static org.junit.Assert.*;
 /**
  * Executes tests of the command-line arguments to SqlLine.
  */
-@RunWith(JMockit.class)
 public class SqlLineArgsTest {
   private static final ConnectionSpec CONNECTION_SPEC = ConnectionSpec.HSQLDB;
   private ConnectionSpec connectionSpec;
@@ -868,7 +865,8 @@ public class SqlLineArgsTest {
       // If sqlline is not initialized, handleSQLException will print
       // the entire stack trace.
       // To prevent that, forcibly set init to true.
-      Deencapsulation.setField(sqlLine, "initComplete", true);
+      FieldReflection
+          .setField(sqlLine.getClass(), sqlLine, "initComplete", true);
       sqlLine.getConnection();
       sqlLine.runCommands(
           Arrays.asList("CREATE TABLE rsTest ( a int);",
@@ -1295,7 +1293,8 @@ public class SqlLineArgsTest {
       };
       DispatchCallback callback = new DispatchCallback();
       sqlLine.initArgs(args, callback);
-      Deencapsulation.setField(sqlLine, "initComplete", true);
+      FieldReflection
+          .setField(sqlLine.getClass(), sqlLine, "initComplete", true);
       sqlLine.getConnection();
       sqlLine.runCommands(
           Collections.singletonList("!set maxwidth 80"), callback);

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -21,11 +21,9 @@ import org.jline.utils.AttributedStyle;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import mockit.Mock;
 import mockit.MockUp;
-import mockit.integration.junit4.JMockit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -36,7 +34,6 @@ import static sqlline.SqlLineHighlighterLowLevelTest.getSqlLine;
 /**
  * Tests for sql and command syntax highlighting in sqlline.
  */
-@RunWith(JMockit.class)
 public class SqlLineHighlighterTest {
 
   private Map<SqlLine, SqlLineHighlighter> sqlLine2Highlighter;


### PR DESCRIPTION
The PR 
1. bumps jmockit version to 1.44
2. bumps maven-surefire-plugin version to 2.22.1 (jmockit 1.42+ requires 2.21.0+ based on http://jmockit.github.io/tutorial/Introduction.html#runningTests)
3. removes `@RunWith` as it was removed in jmockit 1.42 as mentioned at https://github.com/jmockit/jmockit1/issues/554
4. replaces `Deencapsulation.setField` with `FieldReflection.setField` as `Deencapsulation.setField` marked deprecated in 1.44 and is going to be removed in 1.45 as mentioned at http://jmockit.github.io/changes.html

fixes #252 