### PR TITLE
SQLLINE-239: Add extra confirmation step for destructive commands like e Drop/Delete to avoid accidental executions.

### DIFF
--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -33,6 +33,8 @@ public enum BuiltInProperty implements SqlLineProperty {
   COLOR_SCHEME("colorScheme", Type.STRING, DEFAULT, true, false,
       new Application().getName2HighlightStyle().keySet()),
   COLOR("color", Type.BOOLEAN, false),
+  CONFIRM("confirm", Type.BOOLEAN, false),
+  CONFIRM_PATTERN("confirmPattern", Type.STRING, DEFAULT),
   CSV_DELIMITER("csvDelimiter", Type.STRING, ","),
 
   CSV_QUOTE_CHARACTER("csvQuoteCharacter", Type.CHAR, '\''),

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -490,6 +490,8 @@ public class Commands {
     final Terminal terminal = sqlLine.getLineReader().getTerminal();
     final PrintWriter writer = terminal.writer();
     writer.write(question);
+    writer.write('\n');
+    writer.flush();
     int c;
     // The logic to prevent reaction of SqlLineParser here
     do {
@@ -947,7 +949,16 @@ public class Commands {
 
       try {
         long start = System.currentTimeMillis();
-
+        if (sqlLine.getOpts().getCompiledConfirmPattern().matcher(sql).find()
+              && sqlLine.getOpts().getConfirm()) {
+          String question = sqlLine.loc("really-perform-action");
+          final int userResponse = getUserAnswer(question, 'y', 'n', 'Y', 'N');
+          if (userResponse != 'y') {
+            sqlLine.error(sqlLine.loc("abort-action"));
+            callback.setToFailure();
+            return;
+          }
+        }
         if (call) {
           stmnt = sqlLine.getDatabaseConnection().connection.prepareCall(sql);
           callback.trackSqlQuery(stmnt);

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -63,6 +63,8 @@ help-appconfig: Set custom application configuration class name
 help-set: List / set a sqlline variable
 help-rerun: Execute previous command from the history file
 help-reset: Reset a sqlline variable
+help-confirm: Additional step before executing commands identified by confirmPattern - default: false
+help-confirmPattern: Pattern of commands will prompt for confirmation before execution - default: drop/delete
 variables:\
 \n\
 \nVariables:\
@@ -74,6 +76,9 @@ variables:\
 \ncolor           true/false Control whether color is used for display\
 \ncolorScheme     chester/dark/dracula/light/obsidian/solarized/vs2010\
 \n                           Syntax highlight schema\
+\nconfirm         true/false Prompts for confirmation before running\
+\n                           commands specified in confirmPattern\
+\nconfirmPattern  pattern    Pattern commands to issue prompt before execution\
 \ncsvDelimiter    String     Delimiter in csv outputFormat\
 \ncsvQuoteCharacter char     Quote character in csv outputFormat\
 \ndateFormat      pattern    Format dates using SimpleDateFormat pattern\
@@ -239,8 +244,13 @@ abort-on-error: Aborting command set because "force" is false and \
 
 multiple-matches: Ambiguous command: {0}
 
-really-drop-all: Really drop every table in the database? (y/n)\
+really-drop-all: Really drop every table in the database? (y/n)
 abort-drop-all: Aborting drop all tables.
+
+really-perform-action: Really perform the action on this table? (y/n)
+abort-action: Aborting the action.
+
+default-confirm-pattern: ^(?i:(DROP|DELETE))
 
 drivers-found-count: 0#No driver classes found|1#{0} driver class found|1<{0} driver classes found
 rows-selected: 0#No rows selected|1#{0} row selected|1<{0} rows selected
@@ -263,6 +273,8 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --color=[true/false]            control whether color is used for display\n \
 \  --colorScheme=[chester/dark/dracula/light/obsidian/solarized/vs2010]\
 \                                  Syntax highlight schema\n \
+\  --confirm=[true/false]          confirm before executing commands specified in confirmPattern\n \
+\  --confirmPattern=[pattern]      pattern of commands to prompt confirmation\n \
 \  --csvDelimiter=[delimiter]      Delimiter in csv outputFormat\n \
 \  --csvQuoteCharacter=[char]      Quote character in csv outputFormat\n \
 \  --escapeOutput=[true/false]     escape control symbols in output\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -101,6 +101,8 @@ autocommit
 autosave
 color
 colorScheme
+confirm
+confirmPattern
 csvDelimiter
 csvQuoteCharacter
 dateformat
@@ -234,6 +236,8 @@ autocommit
 autosave
 color
 colorScheme
+confirm
+confirmPattern
 csvDelimiter
 csvQuoteCharacter
 dateformat
@@ -1109,6 +1113,9 @@ autoSave        true/false Automatically save preferences
 color           true/false Control whether color is used for display
 colorScheme     chester/dark/dracula/light/obsidian/solarized/vs2010
                            Syntax highlight schema
+confirm         true/false Prompts for confirmation before running
+                           commands specified in confirmPattern
+confirmPattern  pattern    Pattern commands to issue prompt before execution
 csvDelimiter    String     Delimiter in csv outputFormat
 csvQuoteCharacter char     Quote character in csv outputFormat
 dateFormat      pattern    Format dates using SimpleDateFormat pattern
@@ -2070,6 +2077,8 @@ autocommit
 autosave
 color
 colorScheme
+confirm
+confirmPattern
 csvDelimiter
 csvQuoteCharacter
 dateformat
@@ -2117,6 +2126,14 @@ If true, then output to the terminal will use color for a more pleasing visual e
 colorScheme
 
 If chester/dark/dracula/light/obsidian/solarized/vs2010, then this scheme will be used for command/sql syntax highlighting. If default then there is no syntax highlighting.
+
+confirm
+
+If true, then user will be prompted for confirmation if commands matching with confirmPattern are executed.
+
+confirmPattern
+
+If default with confirm = true, user will be prompted for DROP and DELETE commands, otherwise, for the commands as matched in the pattern.
 
 csvDelimiter
 


### PR DESCRIPTION
Please discard the previous PR(https://github.com/julianhyde/sqlline/pull/249) . Something got messed up and I could not see the changes as expected. 