### PR TITLE
Update junit to junit5 and checkstyle to checkstyle 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,21 +25,22 @@
     <top.dir>${project.basedir}</top.dir>
 
     <!-- The following list is sorted. -->
-    <checkstyle.version>7.8.2</checkstyle.version>
+    <checkstyle.version>8.16</checkstyle.version>
     <docbkx-maven-plugin.version>2.0.17</docbkx-maven-plugin.version>
     <forbiddenapis.version>2.6</forbiddenapis.version>
     <h2.version>1.4.197</h2.version>
+    <hamcrest.version>2.1</hamcrest.version>
     <hsqldb.version>2.4.1</hsqldb.version>
     <jline.version>3.9.0</jline.version>
     <jmockit.version>1.44</jmockit.version>
-    <junit.version>4.12</junit.version>
-    <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+    <junit.version>5.3.2</junit.version>
+    <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-    <maven-jar-plugin.version>3.0.0</maven-jar-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+    <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-javadoc-plugin.additionalOptions>-html5</maven-javadoc-plugin.additionalOptions>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -160,6 +161,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -361,9 +363,27 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/config/checkstyle/checker.xml
+++ b/src/main/config/checkstyle/checker.xml
@@ -254,26 +254,23 @@
       <!-- No extra whitespace around types -->
     <module name="GenericWhitespace"/>
 
-    <!-- Required for SuppressionCommentFilter below -->
-    <module name="FileContentsHolder"/>
-  </module>
+    <!-- Setup special comments to suppress specific checks from source files -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\: stop ([\w\|]+)"/>
+      <property name="onCommentFormat"  value="CHECKSTYLE\: resume ([\w\|]+)"/>
+      <property name="checkFormat"      value="$1"/>
+    </module>
 
-  <!-- Setup special comments to suppress specific checks from source files -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\: stop ([\w\|]+)"/>
-    <property name="onCommentFormat"  value="CHECKSTYLE\: resume ([\w\|]+)"/>
-    <property name="checkFormat"      value="$1"/>
-  </module>
+    <!-- Turn off all checks between OFF and ON -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\: OFF"/>
+      <property name="onCommentFormat"  value="CHECKSTYLE\: ON"/>
+    </module>
 
-  <!-- Turn off all checks between OFF and ON -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\: OFF"/>
-    <property name="onCommentFormat"  value="CHECKSTYLE\: ON"/>
-  </module>
-
-  <!-- Turn off checks for the next N lines. -->
-  <module name="SuppressWithNearbyCommentFilter">
-    <property name="commentFormat" value="CHECKSTYLE: +IGNORE (\d+)"/>
-    <property name="influenceFormat" value="$1"/>
+    <!-- Turn off checks for the next N lines. -->
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE: +IGNORE (\d+)"/>
+      <property name="influenceFormat" value="$1"/>
+    </module>
   </module>
 </module>

--- a/src/test/java/sqlline/CompletionTest.java
+++ b/src/test/java/sqlline/CompletionTest.java
@@ -32,13 +32,11 @@ import org.jline.reader.LineReader;
 import org.jline.reader.impl.LineReaderImpl;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test cases for Completions.
@@ -46,13 +44,13 @@ import static org.junit.Assert.assertThat;
 public class CompletionTest {
   private final SqlLine sqlLine = new SqlLine();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     System.setProperty(TerminalBuilder.PROP_DUMB,
         Boolean.TRUE.toString());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setProperty(TerminalBuilder.PROP_DUMB,
         Boolean.FALSE.toString());
@@ -68,23 +66,15 @@ public class CompletionTest {
     for (char c = 'a'; c <= 'z'; c++) {
       final Set<String> expectedSubSet = filterSet(commandSet, "!" + c);
       final Set<String> actual = getLineReaderCompletedSet(lineReader, "!" + c);
-      assertEquals("Completion for command !" + c, expectedSubSet, actual);
+      assertEquals(expectedSubSet, actual, "Completion for command !" + c);
     }
 
-    // check completions of ! + one symbol
+    // check completions of space + tabs + ! + one symbol
     for (char c = 'a'; c <= 'z'; c++) {
       final Set<String> expectedSubSet = filterSet(commandSet, "!" + c);
       final Set<String> actual =
           getLineReaderCompletedSet(lineReader, "  \t\t  !" + c);
-      assertEquals("Completion for command !" + c, expectedSubSet, actual);
-    }
-
-    // check completions of ! + one symbol
-    for (char c = 'a'; c <= 'z'; c++) {
-      final Set<String> expectedSubSet = filterSet(commandSet, "!" + c);
-      final Set<String> actual =
-          getLineReaderCompletedSet(lineReader, "  \t\t  !" + c);
-      assertEquals("Completion for command !" + c, expectedSubSet, actual);
+      assertEquals(expectedSubSet, actual, "Completion for command !" + c);
     }
 
     // check completions if the whole command is finished
@@ -104,9 +94,9 @@ public class CompletionTest {
           + property.propertyName().toLowerCase(Locale.ROOT);
       final Set<String> actual =
           getLineReaderCompletedSet(lineReader, command + " ");
-      assertEquals("Completion for command '"
-              + resetCommand + property.propertyName() + "'",
-          Collections.singleton(command), actual);
+      assertEquals(Collections.singleton(command), actual,
+          "Completion for command '"
+              + resetCommand + property.propertyName() + "'");
     }
   }
 
@@ -155,11 +145,9 @@ public class CompletionTest {
     try {
       SqlLine sqlLine = new SqlLine();
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      SqlLine.Status status = begin(sqlLine, os, false);
-      // Here the status is SqlLine.Status.OTHER
-      // because of EOF as the result of InputStream which
-      // is not used in the current test so it is ok
-      assertThat(status, equalTo(SqlLine.Status.OTHER));
+      SqlLine.Status status =
+          begin(sqlLine, os, false, "-e", "!set maxwidth 80");
+      assertEquals(status, SqlLine.Status.OK);
       sqlLine.runCommands(new DispatchCallback(),
           "!set maxwidth 80",
           "!connect "

--- a/src/test/java/sqlline/DatabaseMetaDataWrapperTest.java
+++ b/src/test/java/sqlline/DatabaseMetaDataWrapperTest.java
@@ -15,13 +15,13 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 
 import org.hsqldb.jdbc.JDBCDatabaseMetaData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import mockit.Expectations;
 import mockit.Mocked;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Test cases for not supported {@link java.sql.DatabaseMetaData} methods.

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -19,12 +19,11 @@ import java.util.Locale;
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
+import static org.hamcrest.MatcherAssert.assertThat;
 import static sqlline.SqlLineArgsTest.begin;
 
 /**

--- a/src/test/java/sqlline/RowsTest.java
+++ b/src/test/java/sqlline/RowsTest.java
@@ -11,10 +11,10 @@
 */
 package sqlline;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test cases for Rows.

--- a/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterLowLevelTest.java
@@ -19,11 +19,11 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for auxiliary methods in {@link SqlLineHighlighter}.
@@ -32,13 +32,13 @@ public class SqlLineHighlighterLowLevelTest {
   private SqlLine defaultSqlline = null;
   private SqlLineHighlighter defaultHighlighter = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     defaultSqlline = getSqlLine(SqlLineProperty.DEFAULT);
     defaultHighlighter = new SqlLineHighlighter(defaultSqlline);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     defaultSqlline = null;
     defaultHighlighter = null;
@@ -71,7 +71,7 @@ public class SqlLineHighlighterLowLevelTest {
       expectedStyle.singleQuotes.set(0, line.length());
       BitSet actual = new BitSet(line.length());
       defaultHighlighter.handleSqlSingleQuotes(line, actual, 0);
-      assertEquals("Line [" + line + "]", expectedStyle.singleQuotes, actual);
+      assertEquals(expectedStyle.singleQuotes, actual, "Line [" + line + "]");
     }
   }
 
@@ -126,8 +126,8 @@ public class SqlLineHighlighterLowLevelTest {
       expectedStyle.sqlIdentifierQuotes.set(0, line.length());
       BitSet actual = new BitSet(line.length());
       defaultHighlighter.handleSqlIdentifierQuotes(line, "\"", "\"", actual, 0);
-      assertEquals(
-          "Line [" + line + "]", expectedStyle.sqlIdentifierQuotes, actual);
+      assertEquals(expectedStyle.sqlIdentifierQuotes, actual,
+          "Line [" + line + "]");
     }
 
     for (String line : linesRequiredToBeBackTickQuoted) {
@@ -137,7 +137,7 @@ public class SqlLineHighlighterLowLevelTest {
       BitSet actual = new BitSet(line.length());
       defaultHighlighter.handleSqlIdentifierQuotes(line, "`", "`", actual, 0);
       assertEquals(
-          "Line [" + line + "]", expectedStyle.sqlIdentifierQuotes, actual);
+          expectedStyle.sqlIdentifierQuotes, actual, "Line [" + line + "]");
     }
 
     for (String line : linesRequiredToBeSquareBracketQuoted) {
@@ -147,7 +147,7 @@ public class SqlLineHighlighterLowLevelTest {
       BitSet actual = new BitSet(line.length());
       defaultHighlighter.handleSqlIdentifierQuotes(line, "[", "]", actual, 0);
       assertEquals(
-          "Line [" + line + "]", expectedStyle.sqlIdentifierQuotes, actual);
+          expectedStyle.sqlIdentifierQuotes, actual, "Line [" + line + "]");
     }
   }
 
@@ -177,7 +177,7 @@ public class SqlLineHighlighterLowLevelTest {
       expectedStyle.comments.set(0, line.length());
       BitSet actual = new BitSet(line.length());
       defaultHighlighter.handleComments(line, actual, 0, true);
-      assertEquals("Line [" + line + "]", expectedStyle.comments, actual);
+      assertEquals(expectedStyle.comments, actual, "Line [" + line + "]");
     }
   }
 
@@ -203,7 +203,7 @@ public class SqlLineHighlighterLowLevelTest {
       expectedStyle.numbers.set(0, line.length());
       BitSet actual = new BitSet(line.length());
       defaultHighlighter.handleNumbers(line, actual, 0);
-      assertEquals("Line [" + line + "]", expectedStyle.numbers, actual);
+      assertEquals(expectedStyle.numbers, actual, "Line [" + line + "]");
     }
   }
 
@@ -237,10 +237,10 @@ public class SqlLineHighlighterLowLevelTest {
       BitSet actualDoubleQuotes = new BitSet(line.length());
       defaultHighlighter
           .handleQuotesInCommands(line, actualSingleQuotes, actualDoubleQuotes);
-      assertEquals("Line [" + line + "]",
-          expectedStyle.singleQuotes, actualSingleQuotes);
-      assertEquals("Line [" + line + "]",
-          expectedStyle.sqlIdentifierQuotes, actualDoubleQuotes);
+      assertEquals(expectedStyle.singleQuotes, actualSingleQuotes,
+          "Line [" + line + "]");
+      assertEquals(expectedStyle.sqlIdentifierQuotes, actualDoubleQuotes,
+          "Line [" + line + "]");
     }
 
     for (String line : commandsWithDoubleQuotedInput) {
@@ -252,10 +252,10 @@ public class SqlLineHighlighterLowLevelTest {
       BitSet actualDoubleQuotes = new BitSet(line.length());
       defaultHighlighter
           .handleQuotesInCommands(line, actualSingleQuotes, actualDoubleQuotes);
-      assertEquals("Line [" + line + "]",
-          expectedStyle.singleQuotes, actualSingleQuotes);
-      assertEquals("Line [" + line + "]",
-          expectedStyle.sqlIdentifierQuotes, actualDoubleQuotes);
+      assertEquals(expectedStyle.singleQuotes, actualSingleQuotes,
+          "Line [" + line + "]");
+      assertEquals(expectedStyle.sqlIdentifierQuotes, actualDoubleQuotes,
+          "Line [" + line + "]");
     }
   }
 

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -17,16 +17,15 @@ import java.util.Map;
 
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStyle;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import mockit.Mock;
 import mockit.MockUp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static sqlline.SqlLineHighlighterLowLevelTest.ExpectedHighlightStyle;
 import static sqlline.SqlLineHighlighterLowLevelTest.getSqlLine;
 
@@ -43,7 +42,7 @@ public class SqlLineHighlighterTest {
    * with corresponding highlighter into the map like below.
    * @throws Exception if error while sqlline initialization happens
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     sqlLine2Highlighter = new HashMap<>();
     sqlLineWithDefaultColorScheme = getSqlLine(SqlLineProperty.DEFAULT);
@@ -56,7 +55,7 @@ public class SqlLineHighlighterTest {
     sqlLine2Highlighter.put(lightSqlLine, new SqlLineHighlighter(lightSqlLine));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     sqlLine2Highlighter = null;
   }
@@ -773,9 +772,9 @@ public class SqlLineHighlighterTest {
       if (Character.isWhitespace(line.charAt(i))) {
         continue;
       }
-      assertEquals(getFailedStyleMessage(line, i, "default"),
-          i == 0 ? defaultStyle + 32 : defaultStyle,
-          attributedString.styleAt(i).getStyle());
+      assertEquals(i == 0 ? defaultStyle + 32 : defaultStyle,
+          attributedString.styleAt(i).getStyle(),
+          getFailedStyleMessage(line, i, "default"));
     }
   }
 
@@ -809,14 +808,14 @@ public class SqlLineHighlighterTest {
       int style,
       String styleName) {
     if (styleBitSet.get(i)) {
-      assertEquals(getFailedStyleMessage(line, i, styleName),
-          i == 0 ? style + 32 : style,
-          highlightedLine.styleAt(i).getStyle());
+      assertEquals(i == 0 ? style + 32 : style,
+          highlightedLine.styleAt(i).getStyle(),
+          getFailedStyleMessage(line, i, styleName));
     } else {
       if (!Character.isWhitespace(line.charAt(i))) {
-        assertNotEquals(getNegativeFailedStyleMessage(line, i, styleName),
-            i == 0 ? style + 32 : style,
-            highlightedLine.styleAt(i).getStyle());
+        assertNotEquals(i == 0 ? style + 32 : style,
+            highlightedLine.styleAt(i).getStyle(),
+            getNegativeFailedStyleMessage(line, i, styleName));
       }
     }
   }

--- a/src/test/java/sqlline/SqlLineParserTest.java
+++ b/src/test/java/sqlline/SqlLineParserTest.java
@@ -14,11 +14,12 @@ package sqlline;
 import org.jline.reader.EOFError;
 import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import mockit.Mock;
 import mockit.MockUp;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test cases for SqlLineParser.
@@ -165,7 +166,7 @@ public class SqlLineParserTest {
     for (String line : WRONG_LINES) {
       try {
         parser.parse(line, line.length(), acceptLine);
-        Assert.fail("Missing closing quote or semicolon for line " + line);
+        fail("Missing closing quote or semicolon for line " + line);
       } catch (EOFError eofError) {
         //ok
       }
@@ -181,7 +182,7 @@ public class SqlLineParserTest {
     for (String line : WRONG_LINES) {
       try {
         parser.parse(line, line.length(), acceptLine);
-        Assert.fail("Missing closing quote or semicolon for line " + line);
+        fail("Missing closing quote or semicolon for line " + line);
       } catch (EOFError eofError) {
         //ok
       }

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -13,110 +13,109 @@ package sqlline;
 
 import java.util.Objects;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test cases for SQLLine.
  */
-public class SqlLineTest extends TestCase {
-  /**
-   * Public constructor.
-   */
-  public SqlLineTest() {}
-
-  /**
-   * Public constructor with test name, required by junit.
-   *
-   * @param testName Test name
-   */
-  public SqlLineTest(String testName) {
-    super(testName);
-  }
+public class SqlLineTest {
 
   /**
    * Unit test for {@link SqlLine#splitCompound(String)}.
    */
+  @Test
   public void testSplitCompound() {
     final SqlLine line = new SqlLine();
     String[][] strings;
 
     // simple line
     strings = line.splitCompound("abc de  fgh");
-    assertEquals(new String[][] {{"ABC"}, {"DE"}, {"FGH"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}, {"DE"}, {"FGH"}}, strings);
 
     // line with double quotes
     strings = line.splitCompound("abc \"de fgh\" ijk");
-    assertEquals(new String[][] {{"ABC"}, {"de fgh"}, {"IJK"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}, {"de fgh"}, {"IJK"}}, strings);
 
     // line with double quotes as first and last
     strings = line.splitCompound("\"abc de\"  fgh \"ijk\"");
-    assertEquals(new String[][] {{"abc de"}, {"FGH"}, {"ijk"}}, strings);
+    assertArrayEquals(new String[][] {{"abc de"}, {"FGH"}, {"ijk"}}, strings);
 
     // escaped double quotes, and dots inside quoted identifiers
     strings = line.splitCompound("\"ab.c \"\"de\"  fgh.ij");
-    assertEquals(new String[][] {{"ab.c \"de"}, {"FGH", "IJ"}}, strings);
+    assertArrayEquals(new String[][] {{"ab.c \"de"}, {"FGH", "IJ"}}, strings);
 
     // single quotes do not affect parsing
     strings = line.splitCompound("'abc de'  fgh");
-    assertEquals(new String[][] {{"'ABC"}, {"DE'"}, {"FGH"}}, strings);
+    assertArrayEquals(new String[][] {{"'ABC"}, {"DE'"}, {"FGH"}}, strings);
 
     // incomplete double-quoted identifiers are implicitly completed
     strings = line.splitCompound("abcdefgh   \"ijk");
-    assertEquals(new String[][] {{"ABCDEFGH"}, {"ijk"}}, strings);
+    assertArrayEquals(new String[][] {{"ABCDEFGH"}, {"ijk"}}, strings);
 
     // dot at start of line is illegal, but we are lenient and ignore it
     strings = line.splitCompound(".abc def.gh");
-    assertEquals(new String[][] {{"ABC"}, {"DEF", "GH"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}, {"DEF", "GH"}}, strings);
 
     // spaces around dots are fine
     strings = line.splitCompound("abc de .  gh .i. j");
-    assertEquals(new String[][] {{"ABC"}, {"DE", "GH", "I", "J"}}, strings);
+    assertArrayEquals(
+        new String[][] {{"ABC"}, {"DE", "GH", "I", "J"}}, strings);
 
     // double-quote inside an unquoted identifier is treated like a regular
     // character; should be an error, but we are lenient
     strings = line.splitCompound("abc\"de \"fg\"");
-    assertEquals(new String[][] {{"ABC\"DE"}, {"fg"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC\"DE"}, {"fg"}}, strings);
 
     // null value only if unquoted
     strings = line.splitCompound("abc null");
-    assertEquals(new String[][] {{"ABC"}, {null}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}, {null}}, strings);
     strings = line.splitCompound("abc foo.null.bar");
-    assertEquals(new String[][] {{"ABC"}, {"FOO", null, "BAR"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}, {"FOO", null, "BAR"}}, strings);
     strings = line.splitCompound("abc foo.\"null\".bar");
-    assertEquals(new String[][] {{"ABC"}, {"FOO", "null", "BAR"}}, strings);
+    assertArrayEquals(
+        new String[][] {{"ABC"}, {"FOO", "null", "BAR"}}, strings);
     strings = line.splitCompound("abc foo.\"NULL\".bar");
-    assertEquals(new String[][] {{"ABC"}, {"FOO", "NULL", "BAR"}}, strings);
+    assertArrayEquals(
+        new String[][] {{"ABC"}, {"FOO", "NULL", "BAR"}}, strings);
 
     // trim trailing whitespace and semicolon
     strings = line.splitCompound("abc ;\t     ");
-    assertEquals(new String[][] {{"ABC"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}}, strings);
     // keep semicolon inside line
     strings = line.splitCompound("abc\t;def");
-    assertEquals(new String[][] {{"ABC"}, {";DEF"}}, strings);
+    assertArrayEquals(new String[][] {{"ABC"}, {";DEF"}}, strings);
   }
 
+  @Test
   public void testCenterString() {
     assertEquals("abc", ColorBuffer.centerString("abc", -1));
     assertEquals("abc", ColorBuffer.centerString("abc", 1));
     assertEquals("abc ", ColorBuffer.centerString("abc", 4));
     assertEquals(" abc ", ColorBuffer.centerString("abc", 5));
     // centerString used to have cartesian performance
-    assertEquals(1234567, ColorBuffer.centerString("abc", 1234567).length());
+    assertEquals(
+        1234567, ColorBuffer.centerString("abc", 1234567).length());
   }
 
+  @Test
   public void testLoadingSystemPropertiesOnCreate() {
     System.setProperty("sqlline.Isolation", "TRANSACTION_NONE");
     SqlLine line = new SqlLine();
     try {
-      assertEquals("TRANSACTION_NONE", line.getOpts().getIsolation());
+      assertEquals(
+          "TRANSACTION_NONE", line.getOpts().getIsolation());
     } finally {
       // set back to the default for tests running in the same JVM.
       System.setProperty("sqlline.Isolation", "TRANSACTION_REPEATABLE_READ");
     }
   }
 
+  @Test
   public void testSplit() {
     SqlLine line = new SqlLine();
     String[] strings;
@@ -124,36 +123,38 @@ public class SqlLineTest extends TestCase {
     // query check
     strings = line.split("values (1, cast(null as integer), "
         + "cast(null as varchar(3));", " ");
-    assertEquals(new String[] {"values", "(1,", "cast(null", "as", "integer),",
-        "cast(null", "as", "varchar(3));"}, strings);
+    assertArrayEquals(
+        new String[]{"values", "(1,", "cast(null", "as", "integer),",
+            "cast(null", "as", "varchar(3));"}, strings);
     // space
     strings = line.split("set csvdelimiter ' '", " ");
-    assertEquals(new String[]{"set", "csvdelimiter", " "}, strings);
+    assertArrayEquals(new String[]{"set", "csvdelimiter", " "}, strings);
     // space with double quotes
     strings = line.split("set csvdelimiter \" \"", " ");
-    assertEquals(new String[]{"set", "csvdelimiter", " "}, strings);
+    assertArrayEquals(new String[]{"set", "csvdelimiter", " "}, strings);
     // table and space
     strings = line.split("set csvdelimiter '\t. '", " ");
-    assertEquals(new String[]{"set", "csvdelimiter", "\t. "}, strings);
+    assertArrayEquals(new String[]{"set", "csvdelimiter", "\t. "}, strings);
     // \n
     strings = line.split("set csvdelimiter ' ,\n; '", " ");
-    assertEquals(new String[]{"set", "csvdelimiter", " ,\n; "}, strings);
+    assertArrayEquals(new String[]{"set", "csvdelimiter", " ,\n; "}, strings);
     // double quote inside singles
     strings = line.split("set csvdelimiter ' \"\" \" '", " ");
-    assertEquals(new String[]{"set", "csvdelimiter", " \"\" \" "}, strings);
+    assertArrayEquals(
+        new String[] {"set", "csvdelimiter", " \"\" \" "}, strings);
     // single quotes inside doubles
     strings = line.split("set csvdelimiter \" ' '' \"", " ");
-    assertEquals(new String[]{"set", "csvdelimiter", " ' '' "}, strings);
+    assertArrayEquals(new String[]{"set", "csvdelimiter", " ' '' "}, strings);
     // timestamp string
     strings = line.split("set timestampformat 01/01/1970T12:32:12", " ");
-    assertEquals(
+    assertArrayEquals(
         new String[]{"set", "timestampformat", "01/01/1970T12:32:12"}, strings);
 
     strings = line.split("?", " ");
-    assertEquals(new String[]{"?"}, strings);
+    assertArrayEquals(new String[]{"?"}, strings);
 
     strings = line.split("#", " ");
-    assertEquals(new String[]{"#"}, strings);
+    assertArrayEquals(new String[]{"#"}, strings);
 
     try {
       line.split("set csvdelimiter '", " ");
@@ -205,6 +206,7 @@ public class SqlLineTest extends TestCase {
     }
   }
 
+  @Test
   public void testNextColorScheme() {
     final SqlLine sqlLine = new SqlLine();
     final String initialScheme = sqlLine.getOpts().getColorScheme();
@@ -219,33 +221,6 @@ public class SqlLineTest extends TestCase {
     }
     assertNotEquals(limit, counter);
     assertEquals(initialScheme, currentScheme);
-  }
-
-  void assertEquals(String[][] expectedses, String[][] actualses) {
-    assertEquals(expectedses.length, actualses.length);
-    for (int i = 0; i < expectedses.length; ++i) {
-      String[] expecteds = expectedses[i];
-      String[] actuals = actualses[i];
-      assertEquals(expecteds.length, actuals.length);
-      for (int j = 0; j < expecteds.length; ++j) {
-        String expected = expecteds[j];
-        String actual = actuals[j];
-        assertEquals(expected, actual);
-      }
-    }
-  }
-
-  void assertEquals(String[] expectedses, String[] actualses) {
-    assertEquals(expectedses.length, actualses.length);
-    for (int j = 0; j < expectedses.length; ++j) {
-      String expected = expectedses[j];
-      String actual = actualses[j];
-      if (expected == null) {
-        assertNull(actual);
-      } else {
-        assertEquals(expected, actual);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
The PR
1. updates dependencies 
    checkstyle 7.8.2 => 8.16
    junit 4.12  => 5.3.2
    maven-assembly-plugin 3.0.0 => 3.1.1
    maven-dependency-plugin 2.10 => 3.1.1
    maven-enforcer-plugin 3.0.0-M1 => 3.0.0-M2
    maven-jar-plugin 3.0.0 => 3.1.1
2. introduces dependency to hamcrest as it is not embedded into junit5
3. moves `SuppressionCommentFilter`, `SuppressionCommentFilter`, `SuppressWithNearbyCommentFilter` under `TreeWalker` and removes `FileContentsHolder` as it is declared in checkstyle's RN http://checkstyle.sourceforge.net/releasenotes.html#Release_8.2
4. Updates usage of `assertEquals` as its signature changed (message started to be the last argument)
5. Use `assertArrayEquals` where it is possible
6. Use `Files.createTempFile` for temporary files as junit5 has limited support of temporary files

fixes #265 