### PR TITLE
[SQLLINE-270] Remove maven-compiler-plugin from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,14 +250,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-          <compilerArgument>-Xlint:deprecation</compilerArgument>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>


### PR DESCRIPTION
The PR applies the same approach as at https://issues.apache.org/jira/browse/CALCITE-2836
fixes #270 
thanks @risdenk