### PR TITLE
[SQLLINE-273] Failed to generate javadoc on JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
         <configuration>
           <additionalOptions>${maven-javadoc-plugin.additionalOptions}</additionalOptions>
           <show>public</show>
+          <source>${maven.compiler.source}</source>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The PR fixes https://github.com/julianhyde/sqlline/issues/273.