### PR TITLE
Fixed attempt to retrieve from close ResultSet

### DIFF
--- a/src/main/java/sqlline/BufferedRows.java
+++ b/src/main/java/sqlline/BufferedRows.java
@@ -111,9 +111,11 @@ class BufferedRows extends Rows {
         list.add(new Row(columnCount, rs));
       }
     } else {
-      while (rs.next()) {
-        final Row row = new Row(columnCount, rs);
-        list.add(row);
+      if (!rs.isClosed()) {
+        while (rs.next()) {
+          final Row row = new Row(columnCount, rs);
+          list.add(row);
+        }
       }
     }
     ++batch;


### PR DESCRIPTION
Hello! I've been trying to use sqlline with DB2 Developer C running in a docker container.  What I noticed was, when I was running a SELECT I'd always get an error about a closed result set after all the results had been printed (INSERT, UPDATE work fine).

`| 2019-05-08 17:16:06.93881  |                  | null                       | 2019-05-08 | RDES            | 2019-05-08 16:57:34.708491 | A              | GR559767  | null                      | 1             |
| 2019-05-08 17:17:47.98424  | BX572            | null                       | 2019-05-08 | CBCR            | 2019-05-08 16:57:34.708491 | B              | GR559767  | null                      | 3             |
Error: [jcc][t4][10120][10898][3.72.30] Invalid operation: result set is closed. ERRORCODE=-4470, SQLSTATE=null (state=,code=-4470)
com.ibm.db2.jcc.am.SqlException: [jcc][t4][10120][10898][3.72.30] Invalid operation: result set is closed. ERRORCODE=-4470, SQLSTATE=null
	at com.ibm.db2.jcc.am.hd.a(hd.java:797)
	at com.ibm.db2.jcc.am.hd.a(hd.java:66)
	at com.ibm.db2.jcc.am.hd.a(hd.java:116)
	at com.ibm.db2.jcc.am.ResultSet.checkForClosedResultSet(ResultSet.java:4553)
	at com.ibm.db2.jcc.am.ResultSet.nextX(ResultSet.java:329)
	at com.ibm.db2.jcc.am.ResultSet.next(ResultSet.java:308)
	at sqlline.BufferedRows.nextList(BufferedRows.java:114)
	at sqlline.BufferedRows.hasNext(BufferedRows.java:61)
	at sqlline.TableOutputFormat.print(TableOutputFormat.java:38)
	at sqlline.SqlLine.print(SqlLine.java:1616)
	at sqlline.Commands.execute(Commands.java:982)
	at sqlline.Commands.sql(Commands.java:906)
	at sqlline.SqlLine.dispatch(SqlLine.java:730)
	at sqlline.SqlLine.initArgs(SqlLine.java:457)
	at sqlline.SqlLine.begin(SqlLine.java:523)
	at sqlline.SqlLine.start(SqlLine.java:262)
	at sqlline.SqlLine.main(SqlLine.java:201)
sqlline version 1.8.0-SNAPSHOT
Closing: com.ibm.db2.jcc.t4.b
`

I don't know if this is something non-standard in DB2 JDBC driver or otherwise but I thought I'd investigate. Anyways, the changes in this PR fixed the problem for me - I'd appreciate it if you'd consider including this change in the main repo. Thanks!