### PR TITLE
[SQLLINE-237] Make it possible to submit several sql statements in a …

### DIFF
--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -679,7 +679,7 @@ public class SqlLine {
       return;
     }
 
-    if (isComment(line)) {
+    if (isOneLineComment(line)) {
       callback.setStatus(DispatchCallback.Status.SUCCESS);
       return;
     }
@@ -753,7 +753,21 @@ public class SqlLine {
    * @param line the line to be tested
    * @return true if a comment
    */
-  boolean isComment(String line, boolean trim) {
+  boolean isOneLineComment(String line, boolean trim) {
+    String[] inputLines = line.split("\n");
+    for (String inputLine: inputLines) {
+      if (!isComment(inputLine, trim)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  boolean isOneLineComment(String line) {
+    return isOneLineComment(line, true);
+  }
+
+  private boolean isComment(String line, boolean trim) {
     final String trimmedLine = trim ? line.trim() : line;
     for (String comment: getDialect().getSqlLineOneLineComments()) {
       if (trimmedLine.startsWith(comment)) {
@@ -761,10 +775,6 @@ public class SqlLine {
       }
     }
     return false;
-  }
-
-  boolean isComment(String line) {
-    return isComment(line, true);
   }
 
   /**

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -57,7 +57,7 @@ public class SqlLineHighlighter extends DefaultHighlighter {
       final boolean isCommandPresent =
           trimmed.startsWith(SqlLine.COMMAND_PREFIX);
       final boolean isComment =
-          !isCommandPresent && sqlLine.isComment(trimmed, false);
+          !isCommandPresent && sqlLine.isOneLineComment(trimmed, false);
       final boolean isSql = !isComment
           && isSqlQuery(trimmed, isCommandPresent);
 

--- a/src/main/java/sqlline/SqlLineParser.java
+++ b/src/main/java/sqlline/SqlLineParser.java
@@ -13,6 +13,7 @@ package sqlline;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.jline.reader.EOFError;
 import org.jline.reader.ParsedLine;
@@ -272,6 +273,13 @@ public class SqlLineParser extends DefaultParser {
         }
       }
 
+      if (line.endsWith("\n")
+          && sqlLine.getLineReader() != null
+          && !Objects.equals(line,
+              sqlLine.getLineReader().getBuffer().toString())) {
+        throw new EOFError(-1, -1, "Line continues",
+            getPaddedPrompt(""));
+      }
       String openingQuote = quoteStart >= 0
           ? line.substring(quoteStart, quoteStart + 1) : null;
       return new ArgumentList(line, words, wordIndex, wordCursor,
@@ -333,7 +341,7 @@ public class SqlLineParser extends DefaultParser {
   static boolean isSql(SqlLine sqlLine, String line, ParseContext context) {
     String trimmedLine = trimLeadingSpacesIfPossible(line, context);
     return !trimmedLine.isEmpty()
-        && !sqlLine.isComment(trimmedLine, false)
+        && !sqlLine.isOneLineComment(trimmedLine, false)
         && (trimmedLine.charAt(0) != '!'
             || trimmedLine.regionMatches(0, "!sql", 0, "!sql".length())
             || trimmedLine.regionMatches(0, "!all", 0, "!all".length()));

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -291,7 +291,8 @@ public class SqlLineArgsTest {
 
   @Test
   public void testScriptWithMultilineStatementsInARow() {
-    final String scriptText = "--comment\n\n"
+    final String scriptText = "!set incremental false\n"
+        + "--comment\n\n"
         + "values 1;values 2;";
     checkScriptFile(scriptText, true,
         equalTo(SqlLine.Status.OK),
@@ -310,7 +311,8 @@ public class SqlLineArgsTest {
 
   @Test
   public void testScriptWithMultilineStatementsAndCommentsInARow() {
-    final String scriptText = "--comment;;\n\n"
+    final String scriptText = "!set incremental false\n"
+        + "--comment;;\n\n"
         + "select * from (values ';') t (\";\");/*;select 1;*/values 2;";
     checkScriptFile(scriptText, true,
         equalTo(SqlLine.Status.OK),

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -193,7 +193,7 @@ public class SqlLineArgsTest {
 
     final String script2Text =
         "!set incremental true\n"
-        + "--comment \n values (';\n' /* comment */, '\"'"
+        + "--comment \n --comment2 \nvalues (';\n' /* comment */, '\"'"
         + "/*multiline;\n ;\n comment*/)\n -- ; \n; -- comment";
 
     checkScriptFile(script2Text, true,
@@ -289,6 +289,43 @@ public class SqlLineArgsTest {
         allOf(containsString("multiline2;"), containsString("; string2")));
   }
 
+  @Test
+  public void testScriptWithMultilineStatementsInARow() {
+    final String scriptText = "--comment\n\n"
+        + "values 1;values 2;";
+    checkScriptFile(scriptText, true,
+        equalTo(SqlLine.Status.OK),
+        allOf(
+            containsString("+----+\n"
+                + "| C1 |\n"
+                + "+----+\n"
+                + "| 1  |\n"
+                + "+----+"),
+            containsString("+----+\n"
+                + "| C1 |\n"
+                + "+----+\n"
+                + "| 2  |\n"
+                + "+----+")));
+  }
+
+  @Test
+  public void testScriptWithMultilineStatementsAndCommentsInARow() {
+    final String scriptText = "--comment;;\n\n"
+        + "select * from (values ';') t (\";\");/*;select 1;*/values 2;";
+    checkScriptFile(scriptText, true,
+        equalTo(SqlLine.Status.OK),
+        allOf(
+            containsString("+---+\n"
+                + "| ; |\n"
+                + "+---+\n"
+                + "| ; |\n"
+                + "+---+"),
+            containsString("+----+\n"
+                + "| C1 |\n"
+                + "+----+\n"
+                + "| 2  |\n"
+                + "+----+")));
+  }
   /**
    * Tests sql with H2 specific one-line comment '//'
    */
@@ -386,7 +423,7 @@ public class SqlLineArgsTest {
   @Test
   public void testNull() {
     final String script = "!set incremental true\n"
-        + "values (1, cast(null as integer), cast(null as varchar(3));\n";
+        + "values (1, cast(null as integer), cast(null as varchar(3)));\n";
     checkScriptFile(script, false,
         equalTo(SqlLine.Status.OK),
         containsString(
@@ -413,7 +450,7 @@ public class SqlLineArgsTest {
   public void testTableOutputNullWithoutHeader() {
     final String script = "!set showHeader false\n"
         + "!set incremental true\n"
-        + "values (1, cast(null as integer), cast(null as varchar(3));\n";
+        + "values (1, cast(null as integer), cast(null as varchar(3)));\n";
     checkScriptFile(script, false,
         equalTo(SqlLine.Status.OK),
         containsString("| 1           | null        |     |\n"));
@@ -426,7 +463,7 @@ public class SqlLineArgsTest {
   public void testCsvNullWithoutHeader() {
     final String script = "!set showHeader false\n"
         + "!set outputformat csv\n"
-        + "values (1, cast(null as integer), cast(null as varchar(3));\n";
+        + "values (1, cast(null as integer), cast(null as varchar(3)));\n";
     checkScriptFile(script, false,
         equalTo(SqlLine.Status.OK),
         containsString("'1','null',''\n"));

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -505,6 +505,15 @@ public class SqlLineHighlighterTest {
     expectedStyle.defaults.set(line.indexOf(" dual"), line.length());
     checkLineAgainstAllHighlighters(line, expectedStyle);
 
+    //one line comment first
+    line = "-- \nselect 1;";
+    expectedStyle = new ExpectedHighlightStyle(line.length());
+    expectedStyle.comments.set(0, line.indexOf("select"));
+    expectedStyle.keywords.set(line.indexOf("select"), line.indexOf(" 1"));
+    expectedStyle.defaults.set(line.indexOf(" 1"), line.indexOf("1;"));
+    expectedStyle.numbers.set(line.indexOf("1"));
+    expectedStyle.defaults.set(line.length() - 1);
+    checkLineAgainstAllHighlighters(line, expectedStyle);
   }
 
   /**

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -221,6 +223,19 @@ public class SqlLineTest {
     }
     assertNotEquals(limit, counter);
     assertEquals(initialScheme, currentScheme);
+  }
+
+  @Test
+  public void testOneLineComment() {
+    final SqlLine sqlLine = new SqlLine();
+    // one line comments only
+    assertTrue(sqlLine.isOneLineComment("-- comment"));
+    assertTrue(sqlLine.isOneLineComment("-- comment\n-- comment2"));
+
+    // not only one line comments
+    assertFalse(sqlLine.isOneLineComment("-- comment\n-- comment2\nselect 1;"));
+    assertFalse(sqlLine.isOneLineComment("-- comment\nselect 1-- comment2\n"));
+    assertFalse(sqlLine.isOneLineComment("/*comment*/\n-- comment2\n"));
   }
 }
 


### PR DESCRIPTION
The PR fixes #237 
The idea is to use ';' as separator to get query candidates. Then to check if candidate matches rules for sql queries and if yes then execute it. Otherwise check concat of 2 candidates and etc.

The PR also fixes issue with handling queries with one line comment at the beginning of query.