### PR TITLE
[SQLLINE-298] Add possibility to configure outputformat in one line only

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -1885,7 +1885,12 @@ true
           Set the mode for displaying results from statements.
           This is useful for saving output from SQL statements to
           either a visually pleasing format or an easily
-          parsable format.
+          parsable format. In case of csv or table outputformat
+          there could be specified additional parameters like
+          csv delimiter, csv quote character, max column width.
+          Such settings will change corresponding property's
+          values. If the parameters not specified then property's
+          will be left as is.
           </para>
         </refsect1>
         <refsect1>
@@ -1940,9 +1945,7 @@ NAME        Microsoft
         <refsect1>
           <title>Example of CSV output formatting with different csv delimiter and quote character</title>
           <screen>
-0: jdbc:calcite:model=target/test-classes/mod> !set csvDelimiter ###
-0: jdbc:calcite:model=target/test-classes/mod> !set csvQuoteCharacter @
-0: jdbc:calcite:model=target/test-classes/mod> !set outputFormat csv
+0: jdbc:calcite:model=target/test-classes/mod> !set outputFormat csv ### @
 0: jdbc:calcite:model=target/test-classes/mod> SELECT * FROM COMPANY;
 @COMPANY_ID@###@NAME@
 @1@###@Apple@

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -802,7 +802,25 @@ public class Commands {
   }
 
   public void outputformat(String line, DispatchCallback callback) {
-    set("set " + line, callback);
+    try {
+      String[] lines = sqlLine.split(line);
+      sqlLine.getOpts().setOutputFormat(lines[1]);
+      if ("csv".equals(lines[1])) {
+        if (lines.length > 2) {
+          sqlLine.getOpts().set(BuiltInProperty.CSV_DELIMITER, lines[2]);
+        }
+        if (lines.length > 3) {
+          sqlLine.getOpts().setCsvQuoteCharacter(lines[3]);
+        }
+      } else if ("table".equals(lines[1])) {
+        if (lines.length > 2) {
+          sqlLine.getOpts().set(BuiltInProperty.MAX_COLUMN_WIDTH, lines[2]);
+        }
+      }
+      callback.setToSuccess();
+    } catch (Exception e) {
+      callback.setToFailure();
+    }
   }
 
   public void brief(String line, DispatchCallback callback) {

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -670,7 +670,8 @@ public class SqlLineOpts implements Completer {
 
   public void setCsvQuoteCharacter(String csvQuoteCharacter) {
     if (DEFAULT.equals(csvQuoteCharacter)) {
-      propertiesMap.put(CSV_QUOTE_CHARACTER, CSV_DELIMITER.defaultValue());
+      propertiesMap.put(
+          CSV_QUOTE_CHARACTER, CSV_QUOTE_CHARACTER.defaultValue());
       return;
     } else if (csvQuoteCharacter != null) {
       if (csvQuoteCharacter.length() == 1) {
@@ -683,7 +684,7 @@ public class SqlLineOpts implements Completer {
       }
     }
     sqlLine.error("CsvQuoteCharacter is '"
-        + csvQuoteCharacter + "'; it must be a character of default");
+        + csvQuoteCharacter + "'; it must be a character or default");
   }
 
   public boolean getShowHeader() {

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -1415,6 +1415,8 @@ Synopsis
 Description
 
 Set the mode for displaying results from statements. This is useful for saving output from SQL statements to either a visually pleasing format or an easily parseable format.
+In case of csv or table outputformat there could be specified additional parameters like csv delimiter, csv quote character, max column width.
+Such settings will change corresponding property's values. If the parameters not specified then property's will be left as is.
 
 Example of table output formatting
 
@@ -1450,14 +1452,14 @@ NAME        Microsoft
 
 Example of CSV output formatting
 
-0: jdbc:oracle:thin:@localhost:1521:mydb> !outputformat csv
-0: jdbc:oracle:thin:@localhost:1521:mydb> SELECT * FROM COMPANY;
-'COMPANY_ID','NAME'
-'1','Apple'
-'2','Sun'
-'3','IBM'
-'4','Microsoft'
-4 rows selected (0.012 seconds)
+0: jdbc:calcite:model=target/test-classes/mod> !set outputFormat csv ### @
+0: jdbc:calcite:model=target/test-classes/mod> SELECT * FROM COMPANY;
+@COMPANY_ID@###@NAME@
+@1@###@Apple@
+@2@###@Sun@
+@3@###@IBM@
+@4@###@Microsoft@
+4 rows selected (0.014 seconds)
 
 Example of TSV output formatting
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1149,6 +1149,24 @@ public class SqlLineArgsTest {
   }
 
   @Test
+  public void testCsvOneLiner() {
+    final String script = "!outputformat csv \"'\" @\n"
+        + "values ('#', '@#@', 1, date '1969-07-20', null, ' 1''2\"3\t4');\n"
+        + "!outputformat csv & default\n"
+        + "values ('#', '@#@', 1, date '1969-07-20', null, ' 1''2\"3\t4');\n";
+    final String line1 = "@C1@'@C2@'@C3@'@C4@'@C5@'@C6@";
+    final String line2 =
+        "@#@'@@@#@@@'@1@'@1969-07-20@'@@'@ 1'2\"3\t4@";
+    final String line3 = "'C1'&'C2'&'C3'&'C4'&'C5'&'C6'";
+    final String line4 =
+        "'#'&'@#@'&'1'&'1969-07-20'&''&' 1''2\"3\t4'";
+
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        allOf(containsString(line1), containsString(line2),
+            containsString(line3), containsString(line4)));
+  }
+
+  @Test
   public void testSetForNulls() {
     final String script = "!set numberFormat null\n"
         + "!set\n";


### PR DESCRIPTION
The PR fixes #298 and allows to configure outputformat via one line
for instance
```
!outputformat csv '3' "'"
```
or
```
!outputformat csv '"' default
```
also fix classcast exception after 
`!set csvQuoteCharacter default`
