### PR TITLE
[SQLLINE-305] Quote arguments to allow spaces inside

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1497,7 +1497,6 @@ public class Commands {
       return;
     }
     List<String> cmds = new LinkedList<>();
-
     try {
       try (BufferedReader reader = new BufferedReader(
           new InputStreamReader(
@@ -1663,15 +1662,14 @@ public class Commands {
       sqlLine.error(sqlLine.loc("record-already-running", outputFile));
       return;
     }
-
-    String filename;
-    if (line.length() == "record".length()
-        || (filename =
-            sqlLine.dequote(line.substring("record".length() + 1))) == null) {
+    String[] cmd = sqlLine.split(line);
+    if (cmd.length != 2) {
       sqlLine.error("Usage: record <file name>");
       callback.setToFailure();
       return;
     }
+
+    final String filename = cmd[1];
 
     try {
       outputFile = new OutputFile(expand(filename));

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1149,7 +1149,7 @@ public class Commands {
     }
   }
 
-  public void connect(String line, DispatchCallback callback) {
+  public void connect(String line, DispatchCallback callback) throws Exception {
     String example = "Usage: connect <url> <username> <password> [driver]"
         + SqlLine.getSeparator();
 

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1149,7 +1149,7 @@ public class Commands {
     }
   }
 
-  public void connect(String line, DispatchCallback callback) throws Exception {
+  public void connect(String line, DispatchCallback callback) {
     String example = "Usage: connect <url> <username> <password> [driver]"
         + SqlLine.getSeparator();
 

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1497,6 +1497,7 @@ public class Commands {
       return;
     }
     List<String> cmds = new LinkedList<>();
+
     try {
       try (BufferedReader reader = new BufferedReader(
           new InputStreamReader(

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -399,7 +399,8 @@ public class SqlLine {
     if (url != null || user != null || pass != null || driver != null) {
       String com =
           COMMAND_PREFIX + "connect "
-              + escape(url) + " " + escape(user) + " " + escape(pass) + " "
+              + escapeAndQuote(url) + " " + escapeAndQuote(user)
+              + " " + escapeAndQuote(pass) + " "
               + (driver == null ? "" : driver);
       debug("issuing: " + com);
       dispatch(com, new DispatchCallback());
@@ -407,12 +408,12 @@ public class SqlLine {
 
     if (nickname != null) {
       dispatch(COMMAND_PREFIX
-          + "nickname " + escape(nickname), new DispatchCallback());
+          + "nickname " + escapeAndQuote(nickname), new DispatchCallback());
     }
 
     if (logFile != null) {
       dispatch(COMMAND_PREFIX
-          + "record " + escape(logFile), new DispatchCallback());
+          + "record " + escapeAndQuote(logFile), new DispatchCallback());
     }
 
     if (commandHandler != null) {
@@ -1333,12 +1334,14 @@ public class SqlLine {
     return builder.toString();
   }
 
-  String escape(String input) {
+  // escape and quote if first and last symbols are not equal quotes
+  String escapeAndQuote(String input) {
     if (input == null || input.isEmpty()) {
       return "\"\"";
     }
-    if (input.charAt(0) == input.charAt(input.length() - 1)
-        && input.charAt(0) == '"' || input.charAt(0) == '\'') {
+    if (input.length() > 1
+        && input.charAt(0) == input.charAt(input.length() - 1)
+        && (input.charAt(0) == '"' || input.charAt(0) == '\'')) {
       return input;
     }
     final String escapingSymbols = "\\\"";

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -399,20 +399,22 @@ public class SqlLine {
     if (url != null || user != null || pass != null || driver != null) {
       String com =
           COMMAND_PREFIX + "connect "
-              + (url == null ? "\"\"" : url) + " "
-              + (user == null || user.length() == 0 ? "''" : user) + " "
-              + (pass == null || pass.length() == 0 ? "''" : pass) + " "
+              + "\"" + (url == null ? "" : url) + "\" "
+              + "'" + (user == null || user.length() == 0 ? "" : user) + "' "
+              + "'" + (pass == null || pass.length() == 0 ? "" : pass) + "' "
               + (driver == null ? "" : driver);
       debug("issuing: " + com);
       dispatch(com, new DispatchCallback());
     }
 
     if (nickname != null) {
-      dispatch(COMMAND_PREFIX + "nickname " + nickname, new DispatchCallback());
+      dispatch(COMMAND_PREFIX
+          + "nickname '" + nickname + "'", new DispatchCallback());
     }
 
     if (logFile != null) {
-      dispatch(COMMAND_PREFIX + "record " + logFile, new DispatchCallback());
+      dispatch(COMMAND_PREFIX
+          + "record '" + logFile + "'", new DispatchCallback());
     }
 
     if (commandHandler != null) {

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1277,7 +1277,6 @@ public class SqlLine {
           inQuotes = true;
         }
       } else if (line.regionMatches(i, delim, 0, delim.length())) {
-
         if (inQuotes) {
           i += delim.length() - 1;
           continue;
@@ -1312,6 +1311,7 @@ public class SqlLine {
         ret[i] = dequote(tokens.get(i));
       }
     }
+
     return ret;
   }
 
@@ -1749,6 +1749,7 @@ public class SqlLine {
 
   public int runCommands(List<String> cmds, DispatchCallback callback) {
     int successCount = 0;
+
     try {
       int index = 1;
       int size = cmds.size();

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -603,7 +603,6 @@ public class SqlLine {
           .build()
         : lineReaderBuilder.build();
 
-    lineReader.setOpt(LineReader.Option.MENU_COMPLETE);
     addWidget(lineReader,
         this::nextColorSchemeWidget, "CHANGE_COLOR_SCHEME", alt('h'));
     fileHistory.attach(lineReader);

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -774,7 +774,7 @@ public class SqlLineArgsTest {
     final SqlLine sqlLine = new SqlLine();
     final String script = "!set incremental true\n"
         + "values 1;\n"
-        + "!record " + sqlLine.escape(file.getAbsolutePath()) + "\n"
+        + "!record " + sqlLine.escapeAndQuote(file.getAbsolutePath()) + "\n"
         + "!set outputformat csv\n"
         + "values 2;\n"
         + "!record\n"
@@ -793,7 +793,7 @@ public class SqlLineArgsTest {
                 containsString("1 row selected ("),
                 containsString(
                     "3/8          !record "
-                        + sqlLine.escape(file.getAbsolutePath()) + "\n"),
+                        + sqlLine.escapeAndQuote(file.getAbsolutePath())),
                 containsString(
                     "Saving all output to \"" + file.getAbsolutePath() + "\""),
                 containsString(

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -18,7 +18,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.h2.util.StringUtils;

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -763,39 +763,49 @@ public class SqlLineArgsTest {
    */
   @Test
   public void testRecordFilenameWithSpace() {
-    File file = createTempFile("sqlline file with spaces", ".log");
+    final String fileNameWithSpaces = "sqlline' file\" with\\ spaces";
+    File file = createTempFile(fileNameWithSpaces, ".log");
+    final SqlLine sqlLine = new SqlLine();
     final String script = "!set incremental true\n"
         + "values 1;\n"
-        + "!record " + file.getAbsolutePath() + "\n"
+        + "!record " + sqlLine.escape(file.getAbsolutePath()) + "\n"
         + "!set outputformat csv\n"
         + "values 2;\n"
         + "!record\n"
         + "!set outputformat csv\n"
         + "values 3;\n";
+
     checkScriptFile(script, false,
         equalTo(SqlLine.Status.OK),
-        RegexMatcher.of("(?s)1/8          !set incremental true\n"
-            + "2/8          values 1;\n"
-            + "\\+-------------\\+\n"
-            + "\\|     C1      \\|\n"
-            + "\\+-------------\\+\n"
-            + "\\| 1           \\|\n"
-            + "\\+-------------\\+\n"
-            + "1 row selected \\([0-9.,]+ seconds\\)\n"
-            + "3/8          !record .*.log\n"
-            + "Saving all output to \".*.log\". Enter \"record\" with no arguments to stop it.\n"
-            + "4/8          !set outputformat csv\n"
-            + "5/8          values 2;\n"
-            + "'C1'\n"
-            + "'2'\n"
-            + "1 row selected \\([0-9.,]+ seconds\\)\n"
-            + "6/8          !record\n"
-            + "Recording stopped.\n"
-            + "7/8          !set outputformat csv\n"
-            + "8/8          values 3;\n"
-            + "'C1'\n"
-            + "'3'\n"
-            + "1 row selected \\([0-9.,]+ seconds\\)\n.*"));
+            allOf(containsString("!set incremental true\n"),
+                containsString("values 1;\n"),
+                containsString("+-------------+\n"),
+                containsString("|     C1      |\n"),
+                containsString("+-------------+\n"),
+                containsString("| 1           |\n"),
+                containsString("+-------------+\n"),
+                containsString("1 row selected ("),
+                containsString(
+                    "3/8          !record "
+                        + sqlLine.escape(file.getAbsolutePath()) + "\n"),
+                containsString(
+                    "Saving all output to \"" + file.getAbsolutePath() + "\""),
+                containsString(
+                    "Enter \"record\" with no arguments to stop it.\n"),
+                containsString("4/8          !set outputformat csv\n"),
+                containsString("'C1'\n"),
+                containsString("'2'\n"),
+                containsString("1 row selected ("),
+                containsString("6/8          !record\n"),
+                containsString("Recording stopped.\n"),
+                containsString("7/8          !set outputformat csv\n"),
+                containsString("8/8          values 3;\n"),
+                containsString("'C1'\n"),
+                containsString("'3'\n"),
+                containsString("1 row selected (")
+            )
+    );
+
 
     // Now check that the right stuff got into the file.
     assertFileContains(file,
@@ -2533,8 +2543,8 @@ public class SqlLineArgsTest {
 
       ByteArrayOutputStream os = new ByteArrayOutputStream();
       String[] connectionArgs = new String[]{
-          "-u", ConnectionSpec.H2.url, "-n", "user name",
-          "-p", "user password",
+          "-u", ConnectionSpec.H2.url, "-n", "\"user'\\\" name\"",
+          "-p", "\"user \\\"'\\\"password\"",
           "-e", "!set maxwidth 80"};
       begin(sqlLine, os, false, connectionArgs);
 
@@ -2542,8 +2552,9 @@ public class SqlLineArgsTest {
       Properties infoProperties =
           FieldReflection.getField(
               DatabaseConnection.class, "info", databaseConnection[0]);
-      assertEquals("user name", infoProperties.getProperty("user"));
-      assertEquals("user password", infoProperties.getProperty("password"));
+      assertEquals("user'\" name", infoProperties.getProperty("user"));
+      assertEquals("user \"'\"password",
+          infoProperties.getProperty("password"));
     } catch (Throwable t) {
       throw new RuntimeException(t);
     }
@@ -2561,17 +2572,18 @@ public class SqlLineArgsTest {
       };
       final SqlLine sqlLine = new SqlLine();
       ByteArrayOutputStream os = new ByteArrayOutputStream();
+      final String filename = "file' with\\\" spaces";
       String[] connectionArgs = new String[] {
           "-u", ConnectionSpec.H2.url,
           "-n", ConnectionSpec.H2.username,
           "-p", ConnectionSpec.H2.password,
           "-nn", "nickname with spaces",
-          "-log", "target/file with spaces",
+          "-log", "target/" + filename,
           "-e", "!set maxwidth 80"};
       begin(sqlLine, os, false, connectionArgs);
 
       assertThat("file with spaces",
-          Files.exists(Paths.get("target", "file with spaces")));
+          Files.exists(Paths.get("target", filename)));
       assertEquals("nickname with spaces", nicknames[0]);
     } catch (Throwable t) {
       throw new RuntimeException(t);

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -258,10 +258,41 @@ public class SqlLineTest {
   }
 
   @Test
-  public void testIsCharEscape() {
+  public void testIsCharEscaped() {
     final SqlLine sqlLine = new SqlLine();
     assertTrue(sqlLine.isCharEscaped("\\'", 1));
     assertFalse(sqlLine.isCharEscaped("\\\\\'", 3));
+  }
+
+  @Test
+  public void testEscapeAndQuote() {
+    final SqlLine sqlLine = new SqlLine();
+    assertEquals("\"\"", sqlLine.escapeAndQuote(""));
+    assertEquals("\"\"", sqlLine.escapeAndQuote(null));
+    assertEquals("\"a\"", sqlLine.escapeAndQuote("a"));
+    assertEquals("\"a b\"", sqlLine.escapeAndQuote("a b"));
+    assertEquals("\"\\\\\"", sqlLine.escapeAndQuote("\\"));
+    assertEquals("\"\\\"\"", sqlLine.escapeAndQuote("\""));
+    assertEquals("\"'\"", sqlLine.escapeAndQuote("'"));
+    assertEquals("\"a\\\\ b\"", sqlLine.escapeAndQuote("a\\ b"));
+    assertEquals("\"a\\\\ ' b\"", sqlLine.escapeAndQuote("a\\ ' b"));
+    assertEquals("\"a\\\\ ' \\\"b\"", sqlLine.escapeAndQuote("a\\ ' \"b"));
+  }
+
+  @Test
+  public void testUnescape() {
+    final SqlLine sqlLine = new SqlLine();
+    assertEquals("\"\"", sqlLine.unescape(sqlLine.escapeAndQuote("")));
+    assertEquals("\"\"", sqlLine.unescape(sqlLine.escapeAndQuote(null)));
+    assertEquals("\"a\"", sqlLine.unescape(sqlLine.escapeAndQuote("a")));
+    assertEquals("\"a b\"", sqlLine.unescape(sqlLine.escapeAndQuote("a b")));
+    assertEquals("\"\\\"", sqlLine.unescape(sqlLine.escapeAndQuote("\\")));
+    assertEquals("\"\"\"", sqlLine.unescape(sqlLine.escapeAndQuote("\"")));
+    assertEquals("\"'\"", sqlLine.unescape(sqlLine.escapeAndQuote("'")));
+    assertEquals("\"a\\ b\"",
+        sqlLine.unescape(sqlLine.escapeAndQuote("a\\ b")));
+    assertEquals("\"a\\\\ ' b\"", sqlLine.escapeAndQuote("a\\ ' b"));
+    assertEquals("\"a\\\\ ' \\\"b\"", sqlLine.escapeAndQuote("a\\ ' \"b"));
   }
 }
 

--- a/src/test/java/sqlline/SqlLineTest.java
+++ b/src/test/java/sqlline/SqlLineTest.java
@@ -168,6 +168,15 @@ public class SqlLineTest {
     strings = line.split("#", " ");
     assertArrayEquals(new String[]{"#"}, strings);
 
+    strings = line.split("set \"sec\\\"ret\"", " ");
+    assertArrayEquals(new String[] {"set", "sec\"ret"}, strings);
+
+    strings = line.split("set \"sec\\\"'ret\"", " ");
+    assertArrayEquals(new String[] {"set", "sec\"'ret"}, strings);
+
+    strings = line.split("set \"sec\\\"ret\"", " ");
+    assertArrayEquals(new String[] {"set", "sec\"ret"}, strings);
+
     try {
       line.split("set csvdelimiter '", " ");
       fail("Non-paired quote is not allowed");
@@ -246,6 +255,13 @@ public class SqlLineTest {
     assertFalse(sqlLine.isOneLineComment("-- comment\n-- comment2\nselect 1;"));
     assertFalse(sqlLine.isOneLineComment("-- comment\nselect 1-- comment2\n"));
     assertFalse(sqlLine.isOneLineComment("/*comment*/\n-- comment2\n"));
+  }
+
+  @Test
+  public void testIsCharEscape() {
+    final SqlLine sqlLine = new SqlLine();
+    assertTrue(sqlLine.isCharEscaped("\\'", 1));
+    assertFalse(sqlLine.isCharEscaped("\\\\\'", 3));
   }
 }
 


### PR DESCRIPTION
The PR allows to have spaces in sqlline's arguments such as user names, passwords, filenames, nicknames.
fixes #305 