### PR TITLE
[SQLLINE-302] Make tests running with its own sqlline.properties via …

### DIFF
--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -34,7 +34,7 @@ public enum BuiltInProperty implements SqlLineProperty {
       new Application().getName2HighlightStyle().keySet()),
   COLOR("color", Type.BOOLEAN, false),
   CONFIRM("confirm", Type.BOOLEAN, false),
-  CONFIRM_PATTERN("confirmPattern", Type.STRING, DEFAULT),
+  CONFIRM_PATTERN("confirmPattern", Type.STRING, "^(?i:(DROP|DELETE))"),
   CSV_DELIMITER("csvDelimiter", Type.STRING, ","),
 
   CSV_QUOTE_CHARACTER("csvQuoteCharacter", Type.CHAR, '\''),
@@ -70,6 +70,8 @@ public enum BuiltInProperty implements SqlLineProperty {
   OUTPUT_FORMAT("outputFormat", Type.STRING, "table"),
   PROMPT("prompt", Type.STRING, "sqlline> "),
   PROMPT_SCRIPT("promptScript", Type.STRING, ""),
+  PROPERTIES_FILE("propertiesFile", Type.STRING,
+      new File(SqlLineOpts.saveDir(), "sqlline.properties").getAbsolutePath()),
   RIGHT_PROMPT("rightPrompt", Type.STRING, ""),
   ROW_LIMIT("rowLimit", Type.INTEGER, 0),
   SHOW_ELAPSED_TIME("showElapsedTime", Type.BOOLEAN, true),

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -16,6 +16,7 @@ setting-prop: Setting property: {0}
 unknown-prop: Unknown property: {0}
 wrong-prop-type: Property: {0} should be of type {1}
 saving-options: Saving preferences to: {0}
+saving-to-dev-null-not-supported: Saving to /dev/null not supported
 loaded-options: Loaded preferences from: {0}
 no-specified-driver: Could not find driver {0}
 no-specified-driver-use-existing: Could not find driver {0}; using registered driver {1} instead

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,9 +41,13 @@ public class PromptTest {
     sqlLine.getOpts().setPropertiesFile(DEV_NULL);
   }
 
+  @AfterEach
+  private void finish() {
+    sqlLine.setExit(true);
+  }
+
   @Test
   public void testPromptWithoutConnection() {
-    SqlLine sqlLine = new SqlLine();
     // default prompt
     assertThat(sqlLine.getPromptHandler().getPrompt().toAnsi(),
         is(BuiltInProperty.PROMPT.defaultValue()));
@@ -159,7 +164,6 @@ public class PromptTest {
   @Test
   public void testPromptWithConnection() {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
-    SqlLine sqlLine = new SqlLine();
     try {
       final SqlLine.Status status =
           begin(sqlLine, os, false, "-e", "!set maxwidth 80");
@@ -186,7 +190,6 @@ public class PromptTest {
 
   @Test
   public void testPromptWithSchema() {
-    SqlLine sqlLine = new SqlLine();
     sqlLine.getOpts().set(BuiltInProperty.PROMPT, "%u%S>");
 
     sqlLine.runCommands(new DispatchCallback(),
@@ -207,7 +210,6 @@ public class PromptTest {
 
   @Test
   public void testPromptScript() {
-    SqlLine sqlLine = new SqlLine();
     sqlLine.getOpts().set(BuiltInProperty.PROMPT_SCRIPT, "'hel' + 'lo'");
 
     sqlLine.runCommands(new DispatchCallback(),
@@ -228,7 +230,6 @@ public class PromptTest {
 
   @Test
   public void testCustomPromptHandler() {
-    SqlLine sqlLine = new SqlLine();
     sqlLine.runCommands(new DispatchCallback(),
         "!connect "
             + SqlLineArgsTest.ConnectionSpec.H2.url + " "

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -30,6 +31,15 @@ import static sqlline.SqlLineArgsTest.begin;
  * Test cases for prompt and right prompt.
  */
 public class PromptTest {
+  private static final String DEV_NULL = "/dev/null";
+  private SqlLine sqlLine;
+
+  @BeforeEach
+  private void init() {
+    sqlLine = new SqlLine();
+    sqlLine.getOpts().setPropertiesFile(DEV_NULL);
+  }
+
   @Test
   public void testPromptWithoutConnection() {
     SqlLine sqlLine = new SqlLine();
@@ -118,7 +128,6 @@ public class PromptTest {
   @Test
   public void testPromptWithNickname() {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
-    SqlLine sqlLine = new SqlLine();
     try {
       final SqlLine.Status status =
           begin(sqlLine, os, false, "-e", "!set maxwidth 80");


### PR DESCRIPTION
The PR fixes `propertiesFile` which allows to specify file with properties or `/dev/null`.
In case `propertiesFile` specified the properties will be written in this file (except `/dev/null`)
fixes #302 