### PR TITLE
[SQLLINE-314] Description for command name completion candidates depe…

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -3309,6 +3309,14 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           Defaults to 0, which is interpreted as fetching all rows.
         </para>
       </sect1>
+      <sect1 id="setting_showcompletiondesc">
+        <title>showcompletiondesc</title>
+        <para>
+          If <literal>true</literal>, display help description for each
+          completion candidate. Defaults to
+          <literal>true</literal>.
+        </para>
+      </sect1>
       <sect1 id="setting_showheader">
         <title>showheader</title>
         <para>

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -73,6 +73,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   RIGHT_PROMPT("rightPrompt", Type.STRING, ""),
   ROW_LIMIT("rowLimit", Type.INTEGER, 0),
   SHOW_ELAPSED_TIME("showElapsedTime", Type.BOOLEAN, true),
+  SHOW_COMPLETION_DESCR("showCompletionDesc", Type.BOOLEAN, true),
   SHOW_HEADER("showHeader", Type.BOOLEAN, true),
   SHOW_NESTED_ERRS("showNestedErrs", Type.BOOLEAN, false),
   SHOW_WARNINGS("showWarnings", Type.BOOLEAN, true),

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -64,6 +64,7 @@ import static sqlline.BuiltInProperty.OUTPUT_FORMAT;
 import static sqlline.BuiltInProperty.PROMPT;
 import static sqlline.BuiltInProperty.RIGHT_PROMPT;
 import static sqlline.BuiltInProperty.ROW_LIMIT;
+import static sqlline.BuiltInProperty.SHOW_COMPLETION_DESCR;
 import static sqlline.BuiltInProperty.SHOW_ELAPSED_TIME;
 import static sqlline.BuiltInProperty.SHOW_HEADER;
 import static sqlline.BuiltInProperty.SHOW_NESTED_ERRS;
@@ -111,6 +112,8 @@ public class SqlLineOpts implements Completer {
               put(MODE, SqlLineOpts.this::setMode);
               put(NUMBER_FORMAT, SqlLineOpts.this::setNumberFormat);
               put(OUTPUT_FORMAT, SqlLineOpts.this::setOutputFormat);
+              put(SHOW_COMPLETION_DESCR,
+                  SqlLineOpts.this::setShowCompletionDesc);
               put(TIME_FORMAT, SqlLineOpts.this::setTimeFormat);
               put(TIMESTAMP_FORMAT, SqlLineOpts.this::setTimestampFormat);
             }
@@ -146,7 +149,9 @@ public class SqlLineOpts implements Completer {
       Map<BuiltInProperty, Collection<String>> customCompletions) {
     Map<String, Completer> comp = new HashMap<>();
     final String start = "START";
-    comp.put(start, new StringsCompleter("!set"));
+    comp.put(start,
+        new SqlLineCommandCompleter.CommandNameSqlLineCompleter(
+            sqlLine, sqlLine.loc("help-set"), "!set"));
     Collection<BuiltInProperty> booleanProperties = new ArrayList<>();
     Collection<BuiltInProperty> withDefinedAvailableValues = new ArrayList<>();
     StringBuilder sb = new StringBuilder(start + " (");
@@ -494,6 +499,10 @@ public class SqlLineOpts implements Completer {
     return getBoolean(SHOW_WARNINGS);
   }
 
+  public boolean getShowCompletionDescr() {
+    return getBoolean(SHOW_COMPLETION_DESCR);
+  }
+
   public boolean getShowNestedErrs() {
     return getBoolean(SHOW_NESTED_ERRS);
   }
@@ -544,6 +553,11 @@ public class SqlLineOpts implements Completer {
   public void setTimestampFormat(String timestampFormat) {
     set(TIMESTAMP_FORMAT,
         getValidDateTimePatternOrThrow(timestampFormat));
+  }
+
+  public void setShowCompletionDesc(String setShowCompletionDesc) {
+    sqlLine.setCommandCompleter(new SqlLineCommandCompleter(sqlLine));
+    set(SHOW_COMPLETION_DESCR, setShowCompletionDesc);
   }
 
   public String getNullValue() {

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -556,7 +556,6 @@ public class SqlLineOpts implements Completer {
   }
 
   public void setShowCompletionDesc(String setShowCompletionDesc) {
-    sqlLine.setCommandCompleter(new SqlLineCommandCompleter(sqlLine));
     set(SHOW_COMPLETION_DESCR, setShowCompletionDesc);
   }
 

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -122,6 +122,7 @@ variables:\
 \nrightPrompt     pattern    Format right prompt\
 \nrowLimit        integer    Maximum number of rows returned from a query; zero\
 \n                           means no limit\
+\nshowCompletionDesc true/false Display help for completions\
 \nshowElapsedTime true/false Display execution time when verbose\
 \nshowHeader      true/false Show column names in query results\
 \nshowNestedErrs  true/false Display nested errors\
@@ -290,6 +291,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --fastConnect=[true/false]      skip building table/column list for tab-completion\n \
 \  --autoCommit=[true/false]       enable/disable automatic transaction commit\n \
 \  --verbose=[true/false]          show verbose error messages and debug info\n \
+\  --showCompletionDesc=[true/false] display help for completions\n \
 \  --showTime=[true/false]         display execution time when verbose\n \
 \  --showWarnings=[true/false]     display connection warnings\n \
 \  --showNestedErrs=[true/false]   display nested errors\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -1160,6 +1160,7 @@ propertiesFile  path       File from which SQLLine reads properties on
 rightPrompt     pattern    Format right prompt
 rowLimit        integer    Maximum number of rows returned from a query; zero
                            means no limit
+showCompletionDesc true/false Display help for completions
 showElapsedTime true/false Display execution time when verbose
 showHeader      true/false Show column names in query results
 showNestedErrs  true/false Display nested errors


### PR DESCRIPTION
PR allows to show description (help) for each command name.
Theoretically it is possible to do so for properties also however in this case it is required to reconsider the way how help for properties is stored. Currently it is impossible to get help string for specific property.
fixes #314 