### PR TITLE
[SQLLINE-306] Turn off menu because of issue mentioned in #306 

### DIFF
--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -595,6 +595,8 @@ public class SqlLine {
         .terminal(terminal)
         .parser(new SqlLineParser(this))
         .variable(LineReader.HISTORY_FILE, getOpts().getHistoryFile())
+        .option(LineReader.Option.AUTO_LIST, false)
+        .option(LineReader.Option.AUTO_MENU, true)
         .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
     final LineReader lineReader = inputStream == null
         ? lineReaderBuilder

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -780,7 +780,7 @@ public class SqlLineArgsTest {
    */
   @Test
   public void testRecordFilenameWithSpace() {
-    final String fileNameWithSpaces = "sqlline' file\" with\\ spaces";
+    final String fileNameWithSpaces = "sqlline' file with spaces";
     File file = createTempFile(fileNameWithSpaces, ".log");
     final SqlLine sqlLine = new SqlLine();
     final String script = "!set incremental true\n"
@@ -2603,7 +2603,7 @@ public class SqlLineArgsTest {
       };
       final SqlLine sqlLine = new SqlLine();
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      final String filename = "file' with\\\" spaces";
+      final String filename = "file' with spaces";
       String[] connectionArgs = new String[] {
           "-u", ConnectionSpec.H2.url,
           "-n", ConnectionSpec.H2.username,


### PR DESCRIPTION
The PR suggests turning off menu option of jline3 because of issue mentioned in 306.
Currently I was not able to see significant difference between menu and list to make it toggleable.

Also it fixes 2 tests on Windows as Windows do not support `"` in file names.

fixes #306