### PR TITLE
[SQLLINE-327] !reconnect should respect fastconnect property value

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1324,7 +1324,6 @@ public class Commands {
     try {
       sqlLine.getDatabaseConnections().setConnection(connection);
       sqlLine.getDatabaseConnection().getConnection();
-      sqlLine.setCompletions();
       callback.setToSuccess();
     } catch (Exception e) {
       connection.close();

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -180,7 +180,7 @@ class DatabaseConnection {
     }
 
     connect();
-
+    sqlLine.setCompletions();
     return connection;
   }
 

--- a/src/test/java/sqlline/CompletionTest.java
+++ b/src/test/java/sqlline/CompletionTest.java
@@ -151,7 +151,6 @@ public class CompletionTest {
           begin(sqlLine, os, false, "-e", "!set maxwidth 80");
       assertEquals(status, SqlLine.Status.OK);
       sqlLine.runCommands(new DispatchCallback(),
-          "!set maxwidth 80",
           "!connect "
               + SqlLineArgsTest.ConnectionSpec.H2.url + " "
               + SqlLineArgsTest.ConnectionSpec.H2.username + " "
@@ -187,7 +186,6 @@ public class CompletionTest {
           begin(sqlLine, os, false, "-e", "!set maxwidth 80");
       assertEquals(status, SqlLine.Status.OK);
       sqlLine.runCommands(new DispatchCallback(),
-          "!set maxwidth 80",
           "!set fastconnect false",
           "!connect "
               + SqlLineArgsTest.ConnectionSpec.H2.url + " "
@@ -222,7 +220,6 @@ public class CompletionTest {
           begin(sqlLine, os, false, "-e", "!set maxwidth 80");
       assertEquals(status, SqlLine.Status.OK);
       sqlLine.runCommands(new DispatchCallback(),
-          "!set maxwidth 80",
           "!set fastconnect true",
           "!connect "
               + SqlLineArgsTest.ConnectionSpec.H2.url + " "

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -780,7 +780,7 @@ public class SqlLineArgsTest {
    */
   @Test
   public void testRecordFilenameWithSpace() {
-    final String fileNameWithSpaces = "sqlline' file\" with\\ spaces";
+    final String fileNameWithSpaces = "sqlline' file with spaces";
     File file = createTempFile(fileNameWithSpaces, ".log");
     final SqlLine sqlLine = new SqlLine();
     final String script = "!set incremental true\n"
@@ -2603,7 +2603,7 @@ public class SqlLineArgsTest {
       };
       final SqlLine sqlLine = new SqlLine();
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      final String filename = "file' with\\\" spaces";
+      final String filename = "file' with spaces";
       String[] connectionArgs = new String[] {
           "-u", ConnectionSpec.H2.url,
           "-n", ConnectionSpec.H2.username,


### PR DESCRIPTION
The PR fixes `!reconnect` behavior making it respecting `fastconnect` property value and provides tests for that.
Also there are small fixes for tests failing on Windows as Windows does not support `"` in filenames
fixes #327 
