### PR TITLE
[SQLLINE-248] !dropall for specific schemas

### DIFF
--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -975,14 +975,14 @@ public class SqlLine {
         "%");
   }
 
-  ResultSet getTables() throws SQLException {
+  ResultSet getTables(String schemaTemplate) throws SQLException {
     if (!assertConnection()) {
       return null;
     }
 
     return getDatabaseConnection().meta.getTables(
         getDatabaseConnection().meta.getConnection().getCatalog(),
-        null,
+        schemaTemplate,
         "%",
         new String[] {"TABLE"});
   }

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -41,7 +41,7 @@ dbinfo — Provide information about the current database
 describe
 describe — Describe a table
 dropall
-dropall — Drop all tables in the database
+dropall — Drop all tables in the database or in the schema
 exportedkeys
 exportedkeys — List exported foreign keys for a database
 go
@@ -182,7 +182,7 @@ dbinfo — Provide information about the current database
 describe
 describe — Describe a table
 dropall
-dropall — Drop all tables in the database
+dropall — Drop all tables in the database or in the schema
 exportedkeys
 exportedkeys — List exported foreign keys for a database
 go
@@ -411,7 +411,7 @@ dbinfo — Provide information about the current database
 describe
 describe — Describe a table
 dropall
-dropall — Drop all tables in the database
+dropall — Drop all tables in the database or in the schema
 exportedkeys
 exportedkeys — List exported foreign keys for a database
 go
@@ -964,11 +964,11 @@ dropall
 
 Name
 
-dropall — Drop all tables in the database
+dropall — Drop all tables in the database or in the schema
 
 Synopsis
 
-!dropall
+!dropall [schema_pattern]
 
 Description
 


### PR DESCRIPTION
The PR suggests fix of `!dropall` functionality.
Also it generates scripts including schema name to cope with cases of several tables with the same names but under different schemas.
Moreover it allows to specify schema pattern to drop tables.
fixes #248 