### PR TITLE
[SQLLINE-210] Add skip.docbkx property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <scott-data-hsqldb.version>0.1</scott-data-hsqldb.version>
+    <skip.docbkx>false</skip.docbkx>
   </properties>
 
   <licenses>
@@ -124,6 +125,7 @@
             </entity>
           </entities>
           <includes>manual.xml</includes>
+          <skip>${skip.docbkx}</skip>
         </configuration>
       </plugin>
       <plugin>
@@ -432,6 +434,12 @@
       <properties>
         <!-- Javadoc only has a "-html5" flag in JDK 9 and higher. -->
         <maven-javadoc-plugin.additionalOptions />
+      </properties>
+    </profile>
+    <profile>
+      <id>skipDoc</id>
+      <properties>
+        <skip.docbkx>true</skip.docbkx>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <top.dir>${project.basedir}</top.dir>
 
     <!-- The following list is sorted. -->
-    <checkstyle.version>8.22</checkstyle.version>
+    <checkstyle.version>8.23</checkstyle.version>
     <docbkx-maven-plugin.version>2.0.17</docbkx-maven-plugin.version>
     <forbiddenapis.version>2.6</forbiddenapis.version>
     <h2.version>1.4.197</h2.version>
@@ -434,12 +434,6 @@
       <properties>
         <!-- Javadoc only has a "-html5" flag in JDK 9 and higher. -->
         <maven-javadoc-plugin.additionalOptions />
-      </properties>
-    </profile>
-    <profile>
-      <id>skipDoc</id>
-      <properties>
-        <skip.docbkx>true</skip.docbkx>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
As docbkx each time requires internet access then sometimes it could be an issue like mentioned in #210.
The PR offers a different profile which could be used to skip docbkx.