### PR TITLE
Add setReadOnly connection option

### DIFF
--- a/src/main/java/sqlline/Application.java
+++ b/src/main/java/sqlline/Application.java
@@ -275,6 +275,7 @@ public class Application {
         new ReflectiveCommandHandler(sqlLine,
             new StringsCompleter(outputFormats.keySet()), "outputformat"),
         new ReflectiveCommandHandler(sqlLine, empty, "autocommit"),
+        new ReflectiveCommandHandler(sqlLine, empty, "readonly"),
         new ReflectiveCommandHandler(sqlLine, empty, "commit"),
         new ReflectiveCommandHandler(sqlLine, new FileNameCompleter(),
             "properties"),

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -29,6 +29,7 @@ import org.jline.reader.impl.history.DefaultHistory;
 public enum BuiltInProperty implements SqlLineProperty {
 
   AUTO_COMMIT("autoCommit", Type.BOOLEAN, true),
+  READ_ONLY("readOnly", Type.BOOLEAN, false),
   AUTO_SAVE("autoSave", Type.BOOLEAN, false),
   COLOR_SCHEME("colorScheme", Type.STRING, DEFAULT, true, false,
       new Application().getName2HighlightStyle().keySet()),

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -795,6 +795,24 @@ public class Commands {
     callback.setToSuccess();
   }
 
+  public void readonly(String line, DispatchCallback callback)
+      throws SQLException {
+    if (!sqlLine.assertConnection()) {
+      callback.setToFailure();
+      return;
+    }
+
+    if (line.endsWith("on")) {
+      sqlLine.getDatabaseConnection().connection.setReadOnly(true);
+    } else if (line.endsWith("off")) {
+      sqlLine.getDatabaseConnection().connection.setReadOnly(false);
+    }
+
+    sqlLine.showWarnings();
+    sqlLine.readonlyStatus(sqlLine.getDatabaseConnection().connection);
+    callback.setToSuccess();
+  }
+
   public void dbinfo(String line, DispatchCallback callback) {
     if (!sqlLine.assertConnection()) {
       callback.setToFailure();

--- a/src/main/java/sqlline/DatabaseConnection.java
+++ b/src/main/java/sqlline/DatabaseConnection.java
@@ -159,6 +159,13 @@ class DatabaseConnection {
     }
 
     try {
+      connection.setReadOnly(sqlLine.getOpts().getReadOnly());
+      //sqlLine.readonlyStatus(connection);
+    } catch (Exception e) {
+      sqlLine.handleException(e);
+    }
+
+    try {
       // nothing is done off of this command beyond the handle so no
       // need to use the callback.
       sqlLine.getCommands().isolation("isolation: " + sqlLine.getOpts()

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -864,6 +864,10 @@ public class SqlLine {
     }
   }
 
+  void readonlyStatus(Connection c) throws SQLException {
+    debug(loc("readonly-status", c.isReadOnly() + ""));
+  }
+
   void autocommitStatus(Connection c) throws SQLException {
     debug(loc("autocommit-status", c.getAutoCommit() + ""));
   }

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -35,6 +35,7 @@ import org.jline.reader.impl.history.DefaultHistory;
 import sqlline.SqlLineProperty.Type;
 
 import static sqlline.BuiltInProperty.AUTO_COMMIT;
+import static sqlline.BuiltInProperty.READ_ONLY;
 import static sqlline.BuiltInProperty.AUTO_SAVE;
 import static sqlline.BuiltInProperty.COLOR;
 import static sqlline.BuiltInProperty.COLOR_SCHEME;
@@ -495,6 +496,10 @@ public class SqlLineOpts implements Completer {
 
   public boolean getAutoCommit() {
     return getBoolean(AUTO_COMMIT);
+  }
+
+  public boolean getReadOnly() {
+    return getBoolean(READ_ONLY);
   }
 
   public boolean getVerbose() {

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -58,6 +58,7 @@ help-nativesql: Show the native SQL for the specified statement
 help-prompthandler: Set custom prompt handler class name
 help-call: Execute a callable statement
 help-autocommit: Set autocommit mode on or off
+help-readonly: Set readonly mode on or off
 help-commit: Commit the current transaction (if autocommit is off)
 help-rollback: Roll back the current transaction (if autocommit is off)
 help-batch: Start or execute a batch of statements
@@ -122,6 +123,7 @@ variables:\
 \n                           startup; default is\
 \n                           $HOME/.sqlline/sqlline.properties (UNIX, Linux,\
 \n                           macOS), $HOME/sqlline/sqlline.properties (Windows)\
+\nreadOnly        true/false Enable/disable readonly connection\
 \nrightPrompt     pattern    Format right prompt\
 \nrowLimit        integer    Maximum number of rows returned from a query; zero\
 \n                           means no limit\
@@ -220,6 +222,8 @@ isolation-status: Transaction isolation: {0}
 isolation-level-not-supported: Transaction isolation level {0} is not supported. Default ({1}) will be used instead.
 unknown-value: Unknown {0} "{1}". Possible values: {2}
 
+readonly-status: Readonly status: {0}
+
 closed: closed
 open: open
 
@@ -297,6 +301,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --headerInterval=ROWS           the interval between which headers are displayed\n \
 \  --fastConnect=[true/false]      skip building table/column list for tab-completion\n \
 \  --autoCommit=[true/false]       enable/disable automatic transaction commit\n \
+\  --readOnly=[true/false]         enable/disable readonly connection\n \
 \  --verbose=[true/false]          show verbose error messages and debug info\n \
 \  --showCompletionDesc=[true/false] display help for completions\n \
 \  --showLineNumbers=[true/false]  show line numbers while multiline queries\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -74,6 +74,8 @@ properties
 properties — Connect to the database defined in the specified properties file.
 quit
 quit — Exit SQLLine
+readonly
+readonly - Enable or disable readonly connection
 reconnect
 reconnect — Reconnect to the current database
 record


### PR DESCRIPTION
setReadOnly(true) puts the connection in read-only mode as a hint to the driver to enable database optimizations (https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setReadOnly-boolean-).
Some drivers behave differently when this option is enabled, therefore this option can be useful to identify different behaviors