### PR TITLE
[SQLLINE-332] Added historyFlags property to customize !history output, updated docs

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -1453,6 +1453,12 @@ sqlline> !help
 !go               Select the current connection
 !help             Print a summary of command usage
 !history          Display the command history
+                  -d Print timestamps for each event (default for !history)
+                  -f Print full time date stamps in the US format
+                  -E Print full time date stamps in the European format
+                  -i Print full time date stamps in ISO8601 format
+                  -n Suppresses command numbers
+                  -r Reverses the order of the commands
 !importedkeys     List all the imported keys for the specified table
 !indexes          List all the indexes for the specified table
 !isolation        Set the transaction isolation for this connection
@@ -1533,6 +1539,12 @@ sqlline>
           <refname>history</refname>
           <refpurpose>
           Display the command history
+            -d Print timestamps for each event (default for !history)
+            -f Print full time date stamps in the US format
+            -E Print full time date stamps in the European format
+            -i Print full time date stamps in ISO8601 format
+            -n Suppresses command numbers
+            -r Reverses the order of the commands
           </refpurpose>
         </refnamediv>
 

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -47,6 +47,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   HEADER_INTERVAL("headerInterval", Type.INTEGER, 100),
   HISTORY_FILE("historyFile", Type.STRING,
       new File(SqlLineOpts.saveDir(), "history").getAbsolutePath()),
+  HISTORY_FLAGS("historyFlags", Type.STRING, "-d"),
   INCREMENTAL("incremental", Type.BOOLEAN, false),
   INCREMENTAL_BUFFER_ROWS("incrementalBufferRows", Type.INTEGER, 1000),
   ISOLATION("isolation", Type.STRING, "TRANSACTION_REPEATABLE_READ",

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -259,7 +259,7 @@ public class Commands {
           sqlLine.getOutputStream(),
           sqlLine.getErrorStream(),
           argsLine.isEmpty()
-              ? new String[]{"-d"}
+              ? new String[]{sqlLine.getOpts().getHistoryFlags()}
               : sqlLine.split(argsLine, " "));
     } catch (Exception e) {
       callback.setToFailure();

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1471,7 +1471,18 @@ public class SqlLine {
          tok.hasMoreTokens();) {
       String next = tok.nextToken();
       final int x = line.length();
-      line.append(line.length() == 0 ? "" : " ").append(next);
+      final int index = next.indexOf('\n');
+      if (index >= 0) {
+        line.setLength(x + index);
+        buff.append(line).append(' ').append(next, 0, index)
+            .append(SEPARATOR).append(head);
+        line.setLength(0);
+        if (next.length() > index + 1) {
+          line.append(next.substring(index + 1));
+        }
+      } else {
+        line.append(line.length() == 0 ? "" : " ").append(next);
+      }
       if (line.length() > len) {
         // The line is now too long. Backtrack: remove the last word, start a
         // new line containing just that word.

--- a/src/main/java/sqlline/SqlLineCommandCompleter.java
+++ b/src/main/java/sqlline/SqlLineCommandCompleter.java
@@ -43,10 +43,13 @@ class SqlLineCommandCompleter extends AggregateCompleter {
         } else {
           final String commandName = SqlLine.COMMAND_PREFIX + cmd;
           final String helpText = commandHandler.getHelpText();
+          final int firstEndOfLineIndex = helpText.indexOf('\n');
           compl.add(new StringsCompleter(
               new SqlLineCandidate(
                   sqlLine, AttributedString.stripAnsi(commandName),
-                  commandName, sqlLine.loc("command-name"), helpText,
+                  commandName, sqlLine.loc("command-name"),
+                  firstEndOfLineIndex == -1
+                      ? helpText : helpText.substring(0, firstEndOfLineIndex),
                   // there could be whatever else instead helpText
                   // which is the same for commands with all theirs aliases
                   null, helpText, true)));

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -35,6 +35,7 @@ import org.jline.reader.impl.history.DefaultHistory;
 import sqlline.SqlLineProperty.Type;
 
 import static sqlline.BuiltInProperty.AUTO_COMMIT;
+import static sqlline.BuiltInProperty.HISTORY_FLAGS;
 import static sqlline.BuiltInProperty.READ_ONLY;
 import static sqlline.BuiltInProperty.AUTO_SAVE;
 import static sqlline.BuiltInProperty.COLOR;
@@ -922,6 +923,10 @@ public class SqlLineOpts implements Completer {
       compiledConfirmPattern = Pattern.compile(getConfirmPattern());
     }
     return compiledConfirmPattern;
+  }
+
+  public String getHistoryFlags() {
+    return get(HISTORY_FLAGS);
   }
 }
 

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -102,6 +102,7 @@ variables:\
 \nhistoryFile     path       File in which to save command history. Default is\
 \n                           $HOME/.sqlline/history (UNIX, Linux, Mac OS),\
 \n                           $HOME/sqlline/history (Windows)\
+\nhistoryFlags    String     Default flags for !history command\
 \nincremental     true/false Do not receive all rows from server before\
 \n                           printing the first row; uses fewer resources,\
 \n                           especially for long-running queries, but column\
@@ -188,7 +189,13 @@ help-alias: Create a new command alias
 help-unalias: Unset a command alias
 help-scan: Scan for installed JDBC drivers
 help-sql: Execute a SQL command
-help-history: Display the command history
+help-history: Display the command history\n\
+-d Print timestamps for each event (default for !history) \n\
+-f Print full time date stamps in the US format \n\
+-E Print full time date stamps in the European format \n\
+-i Print full time date stamps in ISO8601 format \n\
+-n Suppresses command numbers \n\
+-r Reverses the order of the commands
 help-record: Record all output to the specified file
 help-indexes: List all the indexes for the specified table
 help-primarykeys: List all the primary keys for the specified table
@@ -325,6 +332,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --maxColumnWidth=MAXCOLWIDTH    the maximum width to use when displaying columns\n \
 \  --maxHistoryFileRows=ROWS       the maximum number of history rows to store in history file\n \
 \  --maxHistoryRows=ROWS           the maximum number of history rows to store in memory\n \
+\  --historyFlags=FLAGS            default flags for !history command\n \
 \  --mode=[emacs/vi]               the editing mode\n \
 \  --silent=[true/false]           be more silent\n \
 \  --autosave=[true/false]         automatically save preferences\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -50,6 +50,12 @@ help
 help — Display help information
 history
 history — Display the command history
+  -d Print timestamps for each event (default for !history)
+  -f Print full time date stamps in the US format
+  -E Print full time date stamps in the European format
+  -i Print full time date stamps in ISO8601 format
+  -n Suppresses command numbers
+  -r Reverses the order of the commands
 importedkeys
 importedkeys — List imported foreign keys for a database
 indexes
@@ -193,6 +199,12 @@ help
 help — Display help information
 history
 history — Display the command history
+  -d Print timestamps for each event (default for !history)
+  -f Print full time date stamps in the US format
+  -E Print full time date stamps in the European format
+  -i Print full time date stamps in ISO8601 format
+  -n Suppresses command numbers
+  -r Reverses the order of the commands
 importedkeys
 importedkeys — List imported foreign keys for a database
 indexes
@@ -422,6 +434,12 @@ help
 help — Display help information
 history
 history — Display the command history
+  -d Print timestamps for each event (default for !history)
+  -f Print full time date stamps in the US format
+  -E Print full time date stamps in the European format
+  -i Print full time date stamps in ISO8601 format
+  -n Suppresses command numbers
+  -r Reverses the order of the commands
 importedkeys
 importedkeys — List imported foreign keys for a database
 indexes
@@ -1088,6 +1106,12 @@ sqlline> !help
 !go                 Select the current connection
 !help               Print a summary of command usage
 !history            Display the command history
+                    -d Print timestamps for each event (default for !history)
+                    -f Print full time date stamps in the US format
+                    -E Print full time date stamps in the European format
+                    -i Print full time date stamps in ISO8601 format
+                    -n Suppresses command numbers
+                    -r Reverses the order of the commands
 !importedkeys       List all the imported keys for the specified table
 !indexes            List all the indexes for the specified table
 !isolation          Set the transaction isolation for this connection
@@ -1224,7 +1248,12 @@ history
 Name
 
 history — Display the command history
-
+  -d Print timestamps for each event (default for !history)
+  -f Print full time date stamps in the US format
+  -E Print full time date stamps in the European format
+  -i Print full time date stamps in ISO8601 format
+  -n Suppresses command numbers
+  -r Reverses the order of the commands
 Synopsis
 
 !history


### PR DESCRIPTION
The PR adds `historyFlags` which allows to customize default behavior of `!history` at the same time it is still possible to override it if arguments for history command specified explicitly, for instance `!history -nE` will use `-nE` arguments.

Also added docs. As docs started to take more than one line then for short command description from  #315 only the first line is used while all lines are showing for `!help` commands

fixes #332 