### PR TITLE
[SQLLINE-378] Check for silent property before output info message.

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -682,7 +682,7 @@ public class Commands {
 
     if ("all".equals(propertyName)) {
       sqlLine.setOpts(new SqlLineOpts(sqlLine));
-      sqlLine.output(sqlLine.loc("reset-all-props"));
+      sqlLine.info(sqlLine.loc("reset-all-props"));
       // no need to auto save, since its off by default
       callback.setToSuccess();
       return;
@@ -715,7 +715,7 @@ public class Commands {
         }
       }
       if (res != null) {
-        sqlLine.output(sqlLine.loc(res, key, value));
+        sqlLine.info(sqlLine.loc(res, key, value));
       }
       callback.setToSuccess();
     } else {
@@ -1083,7 +1083,7 @@ public class Commands {
       // CTRL-C'd out of the command. Note it, but don't call it an
       // error.
       callback.setStatus(DispatchCallback.Status.CANCELED);
-      sqlLine.output(sqlLine.loc("command-canceled"));
+      sqlLine.info(sqlLine.loc("command-canceled"));
       return;
     } catch (Exception e) {
       callback.setToFailure();
@@ -1529,7 +1529,7 @@ public class Commands {
       sqlLine.handleException(e);
     }
 
-    sqlLine.output(sqlLine.loc("script-closed", sqlLine.getScriptOutputFile()));
+    sqlLine.info(sqlLine.loc("script-closed", sqlLine.getScriptOutputFile()));
     sqlLine.setScriptOutputFile(null);
     callback.setToSuccess();
   }
@@ -1557,7 +1557,7 @@ public class Commands {
     try {
       outFile = new OutputFile(expand(filename));
       sqlLine.setScriptOutputFile(outFile);
-      sqlLine.output(sqlLine.loc("script-started", outFile));
+      sqlLine.info(sqlLine.loc("script-started", outFile));
       callback.setToSuccess();
     } catch (Exception e) {
       callback.setToFailure();
@@ -1732,7 +1732,7 @@ public class Commands {
       sqlLine.handleException(e);
     }
 
-    sqlLine.output(sqlLine.loc("record-closed", sqlLine.getRecordOutputFile()));
+    sqlLine.info(sqlLine.loc("record-closed", sqlLine.getRecordOutputFile()));
     sqlLine.setRecordOutputFile(null);
     callback.setToSuccess();
   }
@@ -1759,7 +1759,7 @@ public class Commands {
     try {
       outputFile = new OutputFile(expand(filename));
       sqlLine.setRecordOutputFile(outputFile);
-      sqlLine.output(sqlLine.loc("record-started", outputFile));
+      sqlLine.info(sqlLine.loc("record-started", outputFile));
       callback.setToSuccess();
     } catch (Exception e) {
       callback.setToFailure();

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -349,7 +349,7 @@ public class SqlLine {
           if (parts.length >= 2) {
             ret = getOpts().set(parts[0], parts[1], true);
           } else {
-            ret = getOpts().set(parts[0], "true", true);
+            ret = getOpts().setEmptyValue(parts[0], true);
           }
 
           if (!ret) {

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -363,14 +363,10 @@ public class SqlLineOpts implements Completer {
     if (property == null) {
       return false;
     }
-    switch (property.type()) {
-    case BOOLEAN:
-      set(property, true);
-      return true;
-    case STRING:
+    if (property.type() == Type.STRING) {
       set(property, "");
       return true;
-    default:
+    } else {
       sqlLine.error(sqlLine.loc("empty-value-not-supported", property.type()));
     }
     return false;
@@ -378,6 +374,19 @@ public class SqlLineOpts implements Completer {
 
   public void set(String key, String value) {
     set(key, value, false);
+  }
+
+  public boolean set(String key, boolean value, boolean quiet) {
+    final SqlLineProperty property = getSqlLineProperty(key, true);
+    if (property == null || property.type() != Type.BOOLEAN) {
+      sqlLine.error(sqlLine.loc("no-prop-not-supported", key));
+      return false;
+    }
+    if (property == SILENT) {
+      set(PROMPT, "");
+      set(RIGHT_PROMPT, "");
+    }
+    return set(key, String.valueOf(value), quiet);
   }
 
   public boolean set(String key, String value, boolean quiet) {

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -23,6 +23,7 @@ no-specified-driver-use-existing: Could not find driver {0}; using registered dr
 no-specified-prop: Specified property [{0}] does not exist. \
   Use !set command to get list of all available properties.
 no-url: Property "url" is required
+no-prop-not-supported: "--no flag for property {0} not supported"
 reset-all-props: All properties were reset to their defaults.
 reset-prop: [{0}] was reset to [{1}]
 not-a-number: Value for property {0} should be a number. Specified value is: {1}.

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -34,6 +34,7 @@ schema: Schema
 table: Table
 column: Column
 new-size-after-resize: New size: height = {0}, width = {1}
+empty-value-not-supported: Empty value for type {0} not supported
 
 jdbc-level: JDBC level
 compliant: Compliant


### PR DESCRIPTION
Reviewed for output messages and changed output to info to check `silent` property first.
Made possible to specify empty string properties as input arguments e.g.
```
echo "SELECT 1;" | bin/sqlline -u "jdbc:url" -n user -p password --prompt --silent --outputformat=csv > myTable.csv
```
Here `--prompt` means set prompt to empty to not record it to file.

fix #378 