### PR TITLE
[SQLLINE-361] Support patterns for tables, columns, procedures.

### DIFF
--- a/src/main/java/sqlline/Reflector.java
+++ b/src/main/java/sqlline/Reflector.java
@@ -94,7 +94,9 @@ class Reflector {
     if (ob == null || ob.toString().equals("null")) {
       return null;
     }
-    if (toType == String.class) {
+    if (toType == ob.getClass()) {
+      return ob;
+    } else if (toType == String.class) {
       return ob.toString();
     } else if (toType == Byte.class || toType == byte.class) {
       return Byte.valueOf(ob.toString());

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1069,10 +1069,11 @@ public class SqlLine {
    *
    * @param line the line to break up
    * @param keepSqlIdentifierQuotes keep SQL identifiers
+   * @param keepCase keep case
    * @return an array of compound words
    */
   public String[][] splitCompound(
-      String line, boolean keepSqlIdentifierQuotes) {
+      String line, boolean keepSqlIdentifierQuotes, boolean keepCase) {
     final Dialect dialect = getDialect();
 
     int state = SPACE;
@@ -1149,10 +1150,12 @@ public class SqlLine {
           String word = String.copyValueOf(chars, idStart, i - idStart - 1);
           if (word.equalsIgnoreCase("NULL")) {
             word = null;
-          } else if (dialect.isUpper()) {
-            word = word.toUpperCase(Locale.ROOT);
-          } else if (dialect.isLower()) {
-            word = word.toLowerCase(Locale.ROOT);
+          } else if (!keepCase) {
+            if (dialect.isUpper()) {
+              word = word.toUpperCase(Locale.ROOT);
+            } else if (dialect.isLower()) {
+              word = word.toLowerCase(Locale.ROOT);
+            }
           }
           current.add(word);
           state = c == '.' ? DOT_SPACE : SPACE;
@@ -1175,10 +1178,12 @@ public class SqlLine {
       if (state == UNQUOTED) {
         if (word.equalsIgnoreCase("NULL")) {
           word = null;
-        } else if (dialect.isUpper()) {
-          word = word.toUpperCase(Locale.ROOT);
-        } else if (dialect.isLower()) {
-          word = word.toLowerCase(Locale.ROOT);
+        } else if (!keepCase) {
+          if (dialect.isUpper()) {
+            word = word.toUpperCase(Locale.ROOT);
+          } else if (dialect.isLower()) {
+            word = word.toLowerCase(Locale.ROOT);
+          }
         }
       }
       current.add(word);
@@ -1196,6 +1201,11 @@ public class SqlLine {
 
   public String[][] splitCompound(String line) {
     return splitCompound(line, false);
+  }
+
+  public String[][] splitCompound(
+      String line, boolean keepSqlIdentifierQuotes) {
+    return splitCompound(line, keepSqlIdentifierQuotes, false);
   }
 
   Dialect getDialect() {

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -1798,6 +1798,63 @@ public class SqlLineArgsTest {
         allOf(containsString(line0), containsString(line1)));
   }
 
+  @Test
+  public void testTablesWithTablePattern() {
+    connectionSpec = ConnectionSpec.H2;
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!set incremental true\n"
+        + "!tables CATALO%\n";
+    final String line0 =
+        "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |\n";
+    final String line1 =
+        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE |         |       |\n";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        allOf(containsString(line0), containsString(line1)));
+  }
+
+  @Test
+  public void testTablesWithSchemaTableType() {
+    connectionSpec = ConnectionSpec.H2;
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!set incremental true\n"
+        + "!tables INFORMATION_% CAT% \"SYSTEM TABLE\"\n";
+    final String line0 =
+        "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |\n";
+    final String line1 =
+        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE |         |       |\n";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        allOf(containsString(line0), containsString(line1)));
+  }
+
+  @Test
+  public void testColumnsWithSchemaTableType() {
+    connectionSpec = ConnectionSpec.H2;
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!set incremental true\n"
+        + "!columns INFORMATION% CAT% CAT%\n";
+    final String line0 =
+        "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME | COLUMN_NAME |  DATA_TYPE  | TYPE_NAME |\n";
+    final String line1 =
+        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | CATALOG_NAME | 12          | V |\n";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
+        allOf(containsString(line0), containsString(line1)));
+  }
+
+  @Test
+  public void testColumnsWithExtraParameters() {
+    connectionSpec = ConnectionSpec.H2;
+    // Set width so we don't inherit from the current terminal.
+    final String script = "!set maxwidth 80\n"
+        + "!set incremental true\n"
+        + "!columns INFORMATION% CAT% CAT% wqer\n";
+    final String line0 = "Usage: ";
+    checkScriptFile(script, true, equalTo(SqlLine.Status.OTHER),
+        allOf(containsString(line0)));
+  }
+
   /**
    * Test case for
    * <a href="https://github.com/julianhyde/sqlline/issues/107">[SQLLINE-107]


### PR DESCRIPTION
Add support name patterns for `!tables`, `!columns`, `!procedures` e.g.
```
!tables INFORMATION_SCHEMA % "SYSTEM TABLE"
```
returns tables with table type `SYSTEM TABLE` from `INFORMATION_SCHEMA`. Types could be multiple as `java.sql.DatabaseMetaData#getTables` takes array of table types => it is now also possible with `!tables` e.g.
```
!tables INFORMATION_SCHEMA % "SYSTEM TABLE" TABLE INDEX
```

Besides that `!indexes`, `!primarykeys` also could take not only one argument like before (table name) but several e.g.
```
!indexes <table name>
!indexes <schema name> <table name>
!indexes <schema name> <table name> <unique>
!indexes <schema name> <table name> <unique> <approximate>
```
or 
```
!primarykeys <table name>
!primarykeys <schema name> <table name>
```
improvement for `!columns` fixes #361 