### PR TITLE
[SQLLINE-336][SQLLINE-376] Support plsql, pgsql queries and ability t…

### DIFF
--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -57,6 +57,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   INCREMENTAL_BUFFER_ROWS("incrementalBufferRows", Type.INTEGER, 1000),
   ISOLATION("isolation", Type.STRING, "TRANSACTION_REPEATABLE_READ",
       true, false, new HashSet<>(new Application().getIsolationLevels())),
+  KEEP_SEMICOLON("keepSemicolon", Type.BOOLEAN, false),
   MAX_COLUMN_WIDTH("maxColumnWidth", Type.INTEGER, -1),
   // don't save maxheight, maxwidth: it is automatically set based on
   // the terminal configuration

--- a/src/main/java/sqlline/Dialect.java
+++ b/src/main/java/sqlline/Dialect.java
@@ -13,6 +13,8 @@ package sqlline;
 
 import java.util.Arrays;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -52,6 +54,19 @@ interface Dialect {
    * @return the string containing the extra characters
    */
   String getExtraNameCharacters();
+
+  CodeBlocks getCodeBlocks();
+
+  interface CodeBlocks {
+    default Predicate<String> isBlockStarting() {
+      return null;
+    }
+    Predicate<String> isBlockStarted();
+    default BiPredicate<String, String> isBlockEnding() {
+      return null;
+    }
+    BiPredicate<String, String> isBlockEnded();
+  }
 }
 
 // End Dialect.java

--- a/src/main/java/sqlline/DialectImpl.java
+++ b/src/main/java/sqlline/DialectImpl.java
@@ -29,6 +29,7 @@ class DialectImpl implements Dialect {
   private final boolean storesUpperCaseIdentifier;
   private final boolean storesLowerCaseIdentifier;
   private final String extraNameCharacters;
+  private final CodeBlocks codeBlocks;
 
   static DialectImpl create(Set<String> keywords, String identifierQuote,
       String productName) {
@@ -63,12 +64,13 @@ class DialectImpl implements Dialect {
     }
     return new DialectImpl(keywords2, storesLowerCaseIdentifier,
         storesUpperCaseIdentifier, dialect.getOneLineComments(),
-        openQuote, closeQuote, extraNameCharacters);
+        openQuote, closeQuote, extraNameCharacters, dialect.getCodeBlocks());
   }
 
   private DialectImpl(Set<String> keywords, boolean storesLowerCaseIdentifier,
       boolean storesUpperCaseIdentifier, Set<String> oneLineComments,
-      char openQuote, char closeQuote, String extraNameCharacters) {
+      char openQuote, char closeQuote, String extraNameCharacters,
+      CodeBlocks codeBlocks) {
     this.keywords = Objects.requireNonNull(keywords);
     this.storesLowerCaseIdentifier = storesLowerCaseIdentifier;
     this.storesUpperCaseIdentifier = storesUpperCaseIdentifier;
@@ -76,6 +78,7 @@ class DialectImpl implements Dialect {
     this.openQuote = openQuote;
     this.closeQuote = closeQuote;
     this.extraNameCharacters = extraNameCharacters;
+    this.codeBlocks = codeBlocks;
   }
 
   public static Dialect getDefault() {
@@ -109,6 +112,10 @@ class DialectImpl implements Dialect {
 
   @Override public String getExtraNameCharacters() {
     return extraNameCharacters;
+  }
+
+  @Override public CodeBlocks getCodeBlocks() {
+    return codeBlocks;
   }
 }
 

--- a/src/main/java/sqlline/IncrementalRows.java
+++ b/src/main/java/sqlline/IncrementalRows.java
@@ -26,7 +26,7 @@ class IncrementalRows extends Rows {
   private Row nextRow;
   private boolean endOfResult;
   private boolean normalizingWidths;
-  private DispatchCallback dispatchCallback;
+  private final DispatchCallback dispatchCallback;
 
   IncrementalRows(SqlLine sqlLine, ResultSet rs,
       DispatchCallback dispatchCallback) throws SQLException {

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -56,6 +56,7 @@ import static sqlline.BuiltInProperty.HISTORY_FILE;
 import static sqlline.BuiltInProperty.INCREMENTAL;
 import static sqlline.BuiltInProperty.INCREMENTAL_BUFFER_ROWS;
 import static sqlline.BuiltInProperty.ISOLATION;
+import static sqlline.BuiltInProperty.KEEP_SEMICOLON;
 import static sqlline.BuiltInProperty.MAX_COLUMN_WIDTH;
 import static sqlline.BuiltInProperty.MAX_HEIGHT;
 import static sqlline.BuiltInProperty.MAX_HISTORY_FILE_ROWS;
@@ -834,6 +835,10 @@ public class SqlLineOpts implements Completer {
 
   public boolean getTrimScripts() {
     return getBoolean(TRIM_SCRIPTS);
+  }
+
+  public boolean getKeepSemicolon() {
+    return getBoolean(KEEP_SEMICOLON);
   }
 
   public int getMaxHeight() {

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -123,6 +123,7 @@ variables:\
 \n                           mode; query starts in non-incremental mode, but\
 \n                           after the this many rows, switches to incremental\
 \nisolation       LEVEL      Set transaction isolation level\
+\nkeepSemicolon   true/false Keep semicolon in queries\
 \nmaxColumnWidth  integer    The maximum width to use when displaying columns\
 \nmaxHeight       integer    The maximum height of the terminal\
 \nmaxWidth        integer    The maximum width of the terminal\
@@ -301,6 +302,7 @@ drivers-found-count: 0#No driver classes found|1#{0} driver class found|1<{0} dr
 rows-selected: 0#No rows selected|1#{0} row selected|1<{0} rows selected
 rows-affected: 0#No rows affected|1#{0} row affected|1<{0} rows affected|0>Unknown rows affected
 active-connections: 0#No active connections|1#{0} active connection:|1<{0} active connections:
+script-executed: Script executed
 
 time-ms: ({0,number,#.###} seconds)
 
@@ -366,4 +368,5 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --incrementalBufferRows integer threshold at which to switch to incremental mode\n \
 \  --tableStyle=[default/solid/double_solid/round_corners/bold_header]\n \
 \                                  table output style\
+\  --keepSemicolon=[true/false]    keep semicolon in queries\n \
 \  --help                          display this message

--- a/src/test/java/sqlline/SqlLineParserTest.java
+++ b/src/test/java/sqlline/SqlLineParserTest.java
@@ -11,208 +11,71 @@
 */
 package sqlline;
 
+import java.util.stream.Stream;
+
 import org.jline.reader.EOFError;
 import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import mockit.Mock;
 import mockit.MockUp;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.of;
+import static sqlline.SqlLineParserTest.QueryStatus.WRONG;
+import static sqlline.SqlLineParserTest.QueryStatus.OK;
 
 /**
  * Test cases for SqlLineParser.
  */
 public class SqlLineParserTest {
-  private static final String[] WRONG_LINES = {
-      "!sql",
-      "   !all",
-      " \n select",
-      " \n test ",
-      "/",
-      "select '1';-comment",
-      "\nselect\n '1';- -comment\n",
-      "select '1';comment\n\n",
-      "\nselect '1'; -comment",
-      " select '1';\ncomment",
-      "select '1';\n\n- -",
-      "select '1';\n\n- ",
-      "select '1';\n\n-",
-      "select '1';\n\n/",
-      "select '1';\n \n-/-comment",
-      "select '1'\n;\n-+-comment",
-      "select '1'\n\n;\ncomment",
-      "select '1';/ *comment*/",
-      "select '1';/--*---comment */",
-      "select '1';--/*comment\n*/\n",
-      "select '1';/ *comment*/\n\n",
-      "select '1'; /  *--comment*/",
-      // not ended quoted line
-      "  test ';",
-      " \n test ';'\";",
-      // not ended with ; (existing ; is commented)
-      "select --\n\n--\n--;",
-      "select 1 --; --;",
-      "select /*--\n\n--\n--;",
-      "select /* \n ;",
-      "select /*/;",
-      "select --\n/*\n--\n--;",
-      "select ' ''\n '' '\n /* ;",
-      "select ` ``\n `` `\n /* ;",
-      // not closed quotes
-      "select ''' from t;",
-      "select ``` from t;",
-      "select ''' \n'' \n'' from t;",
-      "select \"\\\" \n\\\" \n\\\" from t;",
-      // not closed brackets
-      "select to_char(123  from dual;",
-      "select sum(count(1)  from dual;",
-      "select [field  from t;",
-      // extra brackets
-      "select to_char)123) from dual;",
-      "select count)123( from dual;",
-      "select sum)count)123(( from dual;",
-      "select sum(count)t.x)) from t;"
-  };
-
-  @Test
-  public void testSqlLineParserForOkLines() {
-    final DefaultParser parser = new SqlLineParser(new SqlLine());
-    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
-    final String[] lines = {
-        // commands
-        "!set",
-        " !history",
-        "   !scan",
-        " \n !set",
-        " \n test;",
-        " \n test';\n;\n';",
-        "select \n 1\n, '\na\n ';",
-        // sql
-        "select 1;",
-        "select '1';",
-        // sqlline command comment with odd number of quotes
-        "  #select '1",
-        "--select '1`",
-        " -- select '\"",
-        // one line comment right after semicolon
-        "select '1';--comment",
-        "select '1';-----comment",
-        "select '1';--comment\n",
-        "select '1';--comment\n\n",
-        "select '1'; --comment",
-        "select '1';\n--comment",
-        "select '1';\n\n--comment",
-        "select '1';\n \n--comment",
-        "select '1'\n;\n--comment",
-        "select '1'\n\n;--comment",
-        "select '1'\n\n;---comment",
-        "select '1'\n\n;-- --comment",
-        "select '1'\n\n;\n--comment",
-        "select '1';/*comment*/",
-        "select '1';/*---comment */",
-        "select '1';/*comment\n*/\n",
-        "select '1';/*comment*/\n\n",
-        "select '1'; /*--comment*/",
-        // /* inside a quoted line
-        "select '1/*' as \"asd\";",
-        "select '/*' as \"asd*/\";",
-        // quoted line
-        "select '1' as `asd`;",
-        "select '1' as `\\`asd\\``;",
-        "select '1' as \"asd\";",
-        "select '1' as \"a's'd\";",
-        "select '1' as \"'a's'd\n\" from t;",
-        "select '1' as \"'a'\\\ns'd\\\n\n\" from t;",
-        "select ' ''1'', ''2''' as \"'a'\\\ns'd\\\n\n\" from t;",
-        "select ' ''1'', ''2''' as \"'a'\\\"\n s'd \\\" \n \\\"\n\" from t;",
-        // not a valid sql, but from sqlline parser's point of view it is ok
-        // as there are no non-closed brackets, quotes, comments
-        // and it ends with a semicolon
-        " \n test;",
-        " \n test';\n;\n';",
-
-        "select sum(my_function(x.[qwe], x.qwe)) as \"asd\" from t;",
-        "select \n 1\n, '\na\n ';",
-        "select /*\njust a comment\n*/\n'1';",
-        "--comment \n values (';\n' /* comment */, '\"'"
-            + "/*multiline;\n ;\n comment*/)\n -- ; \n;",
-
-        // non-closed or extra brackets but commented or quoted
-        "select '1(' from dual;",
-        "select ')1' from dual;",
-        "select 1/*count(123 */ from dual;",
-        "select 2/* [qwe */ from dual;",
-        "select 2 \" [qwe \" from dual;",
-        "select 2 \" ]]][[[ \" from dual;",
-        "select 2 \" ]]]\n[[[ \" from dual;",
-        "select 2 \" \n]]]\n[[[ \n\" from dual;",
-        "select 2 \n --]]]\n --[[[ \n from dual;",
-    };
-    for (String line : lines) {
-      try {
-        parser.parse(line, line.length(), acceptLine);
-      } catch (Throwable t) {
-        System.err.println("Problem line: [" + line + "]");
-        throw t;
-      }
-    }
+  enum QueryStatus {
+    WRONG, OK
   }
 
-  @Test
-  public void testSqlLineParserForWrongLines() {
+  @ParameterizedTest
+  @MethodSource("provideListOfValidLines")
+  public void testSqlLineParserForOkLines(String line) {
     final DefaultParser parser = new SqlLineParser(new SqlLine());
-    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
-    for (String line : WRONG_LINES) {
-      try {
-        parser.parse(line, line.length(), acceptLine);
-        fail("Missing closing quote or semicolon for line " + line);
-      } catch (EOFError eofError) {
-        //ok
-      }
-    }
+    parseValid(parser, line);
   }
 
-  @Test
-  public void testSqlLineParserForWrongLinesWithEmptyPrompt() {
+  @ParameterizedTest
+  @MethodSource("provideListOfInvalidLines")
+  public void testSqlLineParserForWrongLines(String line) {
+    final DefaultParser parser = new SqlLineParser(new SqlLine());
+    parseInvalid(parser, line);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideListOfInvalidLines")
+  public void testSqlLineParserForWrongLinesWithEmptyPrompt(String line) {
     SqlLine sqlLine = new SqlLine();
     sqlLine.getOpts().set(BuiltInProperty.PROMPT, "");
     final DefaultParser parser = new SqlLineParser(sqlLine);
-    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
-    for (String line : WRONG_LINES) {
-      try {
-        parser.parse(line, line.length(), acceptLine);
-        fail("Missing closing comment, quote or semicolon for line " + line);
-      } catch (EOFError eofError) {
-        //ok
-      }
-    }
+    parseInvalid(parser, line);
   }
 
-  @Test
-  public void testSqlLineParserOfWrongLinesForSwitchedOfflineContinuation() {
+  @ParameterizedTest
+  @MethodSource("provideListOfInvalidLines")
+  public void testSqlLineParserOfWrongLinesForSwitchedOfflineContinuation(
+      String line) {
     final SqlLine sqlLine = new SqlLine();
     sqlLine.getOpts().set(BuiltInProperty.USE_LINE_CONTINUATION, false);
     final DefaultParser parser = new SqlLineParser(sqlLine);
-    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
-    for (String line : WRONG_LINES) {
-      try {
-        parser.parse(line, line.length(), acceptLine);
-      } catch (Throwable t) {
-        System.err.println("Problem line: [" + line + "]");
-        throw t;
-      }
-    }
+    parseValid(parser, line);
   }
-
 
   /**
    * In case of exception while {@link sqlline.SqlLineParser#parse}
    * line continuation will be switched off for particular line.
    */
-  @Test
-  public void testSqlLineParserWithException() {
+  @ParameterizedTest
+  @MethodSource("provideListOfInvalidLines")
+  public void testSqlLineParserWithException(String line) {
     new MockUp<SqlLineHighlighter>() {
       @Mock
       private boolean isLineFinishedWithSemicolon(
@@ -224,15 +87,205 @@ public class SqlLineParserTest {
     final SqlLine sqlLine = new SqlLine();
     sqlLine.getOpts().set(BuiltInProperty.USE_LINE_CONTINUATION, false);
     final DefaultParser parser = new SqlLineParser(sqlLine);
-    final Parser.ParseContext acceptLine = Parser.ParseContext.ACCEPT_LINE;
-    for (String line : WRONG_LINES) {
-      try {
-        parser.parse(line, line.length(), acceptLine);
-      } catch (Throwable t) {
-        System.err.println("Problem line: [" + line + "]");
-        throw t;
+    parseValid(parser, line);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideListOfValidPLSQLLines")
+  public void checkPLSQL(
+      String line, final Dialect dialect, QueryStatus status) {
+    new MockUp<DialectImpl>() {
+      @Mock
+      Dialect getDefault() {
+        return dialect;
       }
+    };
+
+    final DefaultParser parser = new SqlLineParser(new SqlLine());
+    if (status == OK) {
+      parseValid(parser, line);
+    } else {
+      parseInvalid(parser, line);
     }
+  }
+
+  private void parseValid(Parser parser, String line) {
+    try {
+      parser.parse(line, line.length(), Parser.ParseContext.ACCEPT_LINE);
+    } catch (Throwable t) {
+      System.err.println("Problem line: [" + line + "]");
+      throw t;
+    }
+  }
+
+  private void parseInvalid(Parser parser, String line) {
+    assertThrows(EOFError.class,
+        () -> parser.parse(
+            line, line.length(), Parser.ParseContext.ACCEPT_LINE));
+  }
+
+  static Stream<Arguments> provideListOfValidPLSQLLines() {
+    return Stream.of(
+      // POSTGRESQL
+      of("$w$ wq $w$;", BuiltInDialect.POSTGRESQL, OK),
+      of("$AbCd$ \"$'\"wq $AbCd$;", BuiltInDialect.POSTGRESQL, OK),
+      of("$w$ wq  $w$\n/* ; */;", BuiltInDialect.POSTGRESQL, OK),
+      of("$w$   $w$\n /* ; */ ;", BuiltInDialect.POSTGRESQL, OK),
+      of("$www$   $www$\n /* dsfdsa' */ ;", BuiltInDialect.POSTGRESQL, OK),
+      of("$wasd$   $wasd$\n /* dsfdsa */ ;", BuiltInDialect.POSTGRESQL, OK),
+      // no semicolon or semicolon commented/quoted
+      of("$w$ wq $$;", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$$ wq $w$;", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$w$ wq $w$", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$w$ wq';' $w$", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$w$ wq --; \n $w$", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$w$ wq  $w$ --;", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$w$ wq  $w$/*;*/", BuiltInDialect.POSTGRESQL, WRONG),
+      // section name not matches
+      of("$AbCd$ wq $Abcd$;", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$AbCd$ '$$'wq $ABcD$;", BuiltInDialect.POSTGRESQL, WRONG),
+      of("$AbCd$ --$'\" \nwq $AbCd$", BuiltInDialect.POSTGRESQL, WRONG),
+
+      // ORACLE
+      of("begin end;", BuiltInDialect.ORACLE, OK),
+      of("begin end\n;", BuiltInDialect.ORACLE, OK),
+      of("begin --$'\" \nwq end;", BuiltInDialect.ORACLE, OK),
+      of("begin --$'\" \nwq end\n;", BuiltInDialect.ORACLE, OK),
+      of("begin --$'\" \nwq end /* */\n;", BuiltInDialect.ORACLE, OK),
+      of("begin --$'\" \nwq end\t;", BuiltInDialect.ORACLE, OK),
+      of("begin --$'\" \nwq loop end loop; /* end */ 'end ;' end ;",
+          BuiltInDialect.ORACLE, OK),
+      of("begin --$'\" \nwq end ;", BuiltInDialect.ORACLE, OK),
+      of("declare integer test := 3; begin --$'\" \nwq end ;",
+          BuiltInDialect.ORACLE, OK),
+      of("integer test := 3; \n\n\nbegin --$'\" \nwq end ;",
+          BuiltInDialect.ORACLE, OK)
+    );
+  }
+
+  static Stream<Arguments> provideListOfInvalidLines() {
+    return Stream.of(
+      of("!sql"),
+      of("   !all"),
+      of(" \n select"),
+      of(" \n test "),
+      of("/"),
+      of("select '1';-comment"),
+      of("\nselect\n '1';- -comment\n"),
+      of("select '1';comment\n\n"),
+      of("\nselect '1'; -comment"),
+      of(" select '1';\ncomment"),
+      of("select '1';\n\n- -"),
+      of("select '1';\n\n- "),
+      of("select '1';\n\n-"),
+      of("select '1';\n\n/"),
+      of("select '1';\n \n-/-comment"),
+      of("select '1'\n;\n-+-comment"),
+      of("select '1'\n\n;\ncomment"),
+      of("select '1';/ *comment*/"),
+      of("select '1';/--*---comment */"),
+      of("select '1';--/*comment\n*/\n"),
+      of("select '1';/ *comment*/\n\n"),
+      of("select '1'; /  *--comment*/"),
+      // not ended quoted line
+      of("  test ';"),
+      of(" \n test ';'\";"),
+      // not ended with ; (existing ; is commented)
+      of("select --\n\n--\n--;"),
+      of("select 1 --; --;"),
+      of("select /*--\n\n--\n--;"),
+      of("select /* \n ;"),
+      of("select /*/;"),
+      of("select --\n/*\n--\n--;"),
+      of("select ' ''\n '' '\n /* ;"),
+      of("select ` ``\n `` `\n /* ;"),
+      // not closed quotes
+      of("select ''' from t;"),
+      of("select ``` from t;"),
+      of("select ''' \n'' \n'' from t;"),
+      of("select \"\\\" \n\\\" \n\\\" from t;"),
+      // not closed brackets
+      of("select to_char(123  from dual;"),
+      of("select sum(count(1)  from dual;"),
+      of("select [field  from t;"),
+      // extra brackets
+      of("select to_char)123) from dual;"),
+      of("select count)123( from dual;"),
+      of("select sum)count)123(( from dual;"),
+      of("select sum(count)t.x)) from t;")
+    );
+  }
+
+  static Stream<Arguments> provideListOfValidLines() {
+    return Stream.of(
+      // commands
+      of("!set"),
+      of(" !history"),
+      of("   !scan"),
+      of(" \n !set"),
+      of(" \n test;"),
+      of(" \n test';\n;\n';"),
+      of("select \n 1\n, '\na\n ';"),
+      // sql
+      of("select 1;"),
+      of("select '1';"),
+      // sqlline command comment with odd number of quotes
+      of("  #select '1"),
+      of("--select '1`"),
+      of(" -- select '\""),
+      // one line comment right after semicolon
+      of("select '1';--comment"),
+      of("select '1';-----comment"),
+      of("select '1';--comment\n"),
+      of("select '1';--comment\n\n"),
+      of("select '1'; --comment"),
+      of("select '1';\n--comment"),
+      of("select '1';\n\n--comment"),
+      of("select '1';\n \n--comment"),
+      of("select '1'\n;\n--comment"),
+      of("select '1'\n\n;--comment"),
+      of("select '1'\n\n;---comment"),
+      of("select '1'\n\n;-- --comment"),
+      of("select '1'\n\n;\n--comment"),
+      of("select '1';/*comment*/"),
+      of("select '1';/*---comment */"),
+      of("select '1';/*comment\n*/\n"),
+      of("select '1';/*comment*/\n\n"),
+      of("select '1'; /*--comment*/"),
+      // /* inside a quoted line
+      of("select '1/*' as \"asd\";"),
+      of("select '/*' as \"asd*/\";"),
+      // quoted line
+      of("select '1' as `asd`;"),
+      of("select '1' as `\\`asd\\``;"),
+      of("select '1' as \"asd\";"),
+      of("select '1' as \"a's'd\";"),
+      of("select '1' as \"'a's'd\n\" from t;"),
+      of("select '1' as \"'a'\\\ns'd\\\n\n\" from t;"),
+      of("select ' ''1'', ''2''' as \"'a'\\\ns'd\\\n\n\" from t;"),
+      of("select ' ''1'', ''2''' as \"'a'\\\"\n s'd \\\" \n \\\"\n\" from t;"),
+      // not a valid sql, but from sqlline parser's point of view it is ok
+      // as there are no non-closed brackets, quotes, comments
+      // and it ends with a semicolon
+      of(" \n test;"),
+      of(" \n test';\n;\n';"),
+
+      of("select sum(my_function(x.[qwe], x.qwe)) as \"asd\" from t;"),
+      of("select \n 1\n, '\na\n ';"),
+      of("select /*\njust a comment\n*/\n'1';"),
+      of("--comment \n values (';\n' /* comment */, '\"'"
+          + "/*multiline;\n ;\n comment*/)\n -- ; \n;"),
+
+      // non-closed or extra brackets but commented or quoted
+      of("select '1(' from dual;"),
+      of("select ')1' from dual;"),
+      of("select 1/*count(123 */ from dual;"),
+      of("select 2/* [qwe */ from dual;"),
+      of("select 2 \" [qwe \" from dual;"),
+      of("select 2 \" ]]][[[ \" from dual;"),
+      of("select 2 \" ]]]\n[[[ \" from dual;"),
+      of("select 2 \" \n]]]\n[[[ \n\" from dual;"),
+      of("select 2 \n --]]]\n --[[[ \n from dual;"));
   }
 }
 


### PR DESCRIPTION
Added initial support for PL/SQL, PL/pgsql queries on dialect level.

demo for [PL/SQL](https://asciinema.org/a/369711?speed=4.0&t=10.0)
[PL/pgsql](https://asciinema.org/a/369714?speed=3.0&t=10.0)
fixes #336 and fixes #376 

unfortunately it seems that retrieval info about code blocks structure  from driver not supported...
that's why this was hard coded for each dialect inside sqlline code.

there was introduced a new property `keepSemicolon` to not remove semicolon from queries/code block end.
By default it is `false` however in case code blocks it will automatically switch to `true` and back after code block executed.
This property will also fix #377 