### PR TITLE
[SQLLINE-157] Column types in header

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -3469,6 +3469,14 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           <literal>true</literal>.
         </para>
       </sect1>
+      <sect1 id="setting_showtypes">
+        <title>showtypes</title>
+        <para>
+          If <literal>true</literal>, display the names of the
+          column types
+          <literal>true</literal>.
+        </para>
+      </sect1>
       <sect1 id="setting_showwarnings">
         <title>showwarnings</title>
         <para>

--- a/src/main/java/sqlline/BufferedRows.java
+++ b/src/main/java/sqlline/BufferedRows.java
@@ -36,6 +36,7 @@ import java.util.List;
 class BufferedRows extends Rows {
   private final ResultSet rs;
   private final Row columnNames;
+  private final Row columnTypes;
   private final int columnCount;
   private final int limit;
   private List<Row> list;
@@ -49,6 +50,7 @@ class BufferedRows extends Rows {
     limit = sqlLine.getOpts().getIncrementalBufferRows();
     columnCount = rsMeta.getColumnCount();
     columnNames = new Row(columnCount);
+    columnTypes = new Row(columnCount, rsMeta::getColumnTypeName);
     list = nextList();
     iterator = list.iterator();
   }
@@ -101,6 +103,9 @@ class BufferedRows extends Rows {
     if (batch == 0) {
       // Add a row of column names as the first row of the first batch.
       list.add(columnNames);
+      if (sqlLine.getOpts().getShowTypes()) {
+        list.add(columnTypes);
+      }
     }
     if (rs.isClosed()) {
       // Result set is closed. Perhaps the driver closed it automatically

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -88,6 +88,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   SHOW_HEADER("showHeader", Type.BOOLEAN, true),
   SHOW_LINE_NUMBERS("showLineNumbers", Type.BOOLEAN, false),
   SHOW_NESTED_ERRS("showNestedErrs", Type.BOOLEAN, false),
+  SHOW_TYPES("showTypes", Type.BOOLEAN, false),
   SHOW_WARNINGS("showWarnings", Type.BOOLEAN, true),
   STRICT_JDBC("strictJdbc", Type.BOOLEAN, false),
   TIME_FORMAT("timeFormat", Type.STRING, DEFAULT),

--- a/src/main/java/sqlline/IncrementalRows.java
+++ b/src/main/java/sqlline/IncrementalRows.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
 class IncrementalRows extends Rows {
   private final ResultSet rs;
   private final Row labelRow;
+  private final Row typesRow;
   private final Row maxRow;
   private Row nextRow;
   private boolean endOfResult;
@@ -35,6 +36,7 @@ class IncrementalRows extends Rows {
     this.dispatchCallback = dispatchCallback;
     final int columnCount = rsMeta.getColumnCount();
     labelRow = new Row(columnCount);
+    typesRow = new Row(columnCount, rsMeta::getColumnTypeName);
     maxRow = new Row(columnCount);
     // pre-compute normalization so we don't have to deal
     // with SQLExceptions later
@@ -94,7 +96,11 @@ class IncrementalRows extends Rows {
     }
 
     Row ret = nextRow;
-    nextRow = null;
+    if (nextRow == labelRow && sqlLine.getOpts().getShowTypes()) {
+      nextRow = typesRow;
+    } else {
+      nextRow = null;
+    }
     return ret;
   }
 

--- a/src/main/java/sqlline/Rows.java
+++ b/src/main/java/sqlline/Rows.java
@@ -202,8 +202,7 @@ abstract class Rows implements Iterator<Rows.Row> {
     return Collections.unmodifiableMap(map);
   }
 
-  @FunctionalInterface
-  interface CheckedFunction<T, R> {
+  @FunctionalInterface interface CheckedFunction<T, R> {
     R apply(T t) throws SQLException;
   }
 

--- a/src/main/java/sqlline/Rows.java
+++ b/src/main/java/sqlline/Rows.java
@@ -202,6 +202,11 @@ abstract class Rows implements Iterator<Rows.Row> {
     return Collections.unmodifiableMap(map);
   }
 
+  @FunctionalInterface
+  interface CheckedFunction<T, R> {
+    R apply(T t) throws SQLException;
+  }
+
   /** Row from a result set. */
   class Row {
     final String[] values;
@@ -212,11 +217,16 @@ abstract class Rows implements Iterator<Rows.Row> {
     protected int[] sizes;
 
     Row(int size) throws SQLException {
+      this(size, rsMeta::getColumnLabel);
+    }
+
+    Row(int size, CheckedFunction<Integer, String> toValue)
+        throws SQLException {
       isMeta = true;
       values = new String[size];
       sizes = new int[size];
       for (int i = 0; i < size; i++) {
-        values[i] = rsMeta.getColumnLabel(i + 1);
+        values[i] = toValue.apply(i + 1);
         sizes[i] = values[i] == null ? 1 : values[i].length();
       }
 

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -74,6 +74,7 @@ import static sqlline.BuiltInProperty.SHOW_ELAPSED_TIME;
 import static sqlline.BuiltInProperty.SHOW_HEADER;
 import static sqlline.BuiltInProperty.SHOW_LINE_NUMBERS;
 import static sqlline.BuiltInProperty.SHOW_NESTED_ERRS;
+import static sqlline.BuiltInProperty.SHOW_TYPES;
 import static sqlline.BuiltInProperty.SHOW_WARNINGS;
 import static sqlline.BuiltInProperty.SILENT;
 import static sqlline.BuiltInProperty.STRICT_JDBC;
@@ -567,6 +568,10 @@ public class SqlLineOpts implements Completer {
 
   public boolean getShowNestedErrs() {
     return getBoolean(SHOW_NESTED_ERRS);
+  }
+
+  public boolean getShowTypes() {
+    return getBoolean(SHOW_TYPES);
   }
 
   public String getNumberFormat() {

--- a/src/main/java/sqlline/TableOutputFormat.java
+++ b/src/main/java/sqlline/TableOutputFormat.java
@@ -66,7 +66,7 @@ class TableOutputFormat implements OutputFormat {
             || headerInterval > 0 && index % headerInterval == 0) {
           if (index == 0) {
             printRow(header, style.getHeaderTopLeft() + hLine,
-                 hLine + style.getHeaderTopRight());
+                hLine + style.getHeaderTopRight());
             printRow(headerCols, style.getHeaderSeparator() + " ",
                 " " + style.getHeaderSeparator());
           } else if (index == 1 && showTypes) {
@@ -79,8 +79,7 @@ class TableOutputFormat implements OutputFormat {
         }
       }
 
-      // don't output the header twice
-      if (!isHeader) {
+      if (!isHeader) { // don't output the header twice
         printRow(attributedString,
             style.getBodySeparator() + " ", " " + style.getBodySeparator());
       }

--- a/src/main/java/sqlline/TableOutputFormat.java
+++ b/src/main/java/sqlline/TableOutputFormat.java
@@ -33,6 +33,7 @@ class TableOutputFormat implements OutputFormat {
     AttributedString bottomHeader = null;
     AttributedString headerCols = null;
     final int width = getCalculatedWidth();
+    final boolean showTypes = sqlLine.getOpts().getShowTypes();
     final TableOutputFormatStyle style =
         BuiltInTableOutputFormatStyles.BY_NAME.get(
             sqlLine.getOpts().getTableStyle());
@@ -43,28 +44,32 @@ class TableOutputFormat implements OutputFormat {
     rows.normalizeWidths(sqlLine.getOpts().getMaxColumnWidth());
 
     while (rows.hasNext()) {
+      final boolean isHeader = index == 0 || index == 1 && showTypes;
       Rows.Row row = rows.next();
       AttributedString attributedString =
-          getOutputString(rows, row, style, index == 0);
+          getOutputString(rows, row, style, isHeader);
       attributedString = attributedString
           .substring(0, Math.min(attributedString.length(), width));
 
-      if (index <= 1) {
-        StringBuilder h = buildHeaderLine(row, style, index == 0, false);
-        StringBuilder bottomH = buildHeaderLine(row, style, false, true);
-        headerCols = index == 0 ? attributedString : headerCols;
-        header = buildHeader(headerCols, h);
-        bottomHeader = buildHeader(headerCols, bottomH);
+      if (index <= 1 || index <= 2 && showTypes) {
+        StringBuilder top = buildHeaderLine(row, style, index == 0, false);
+        StringBuilder bottom = buildHeaderLine(row, style, false, true);
+        headerCols = isHeader ? attributedString : headerCols;
+        header = buildHeader(headerCols, top);
+        bottomHeader = buildHeader(headerCols, bottom);
       }
 
       if (sqlLine.getOpts().getShowHeader()) {
         final int headerInterval =
             sqlLine.getOpts().getHeaderInterval();
-        if (index <= 1
+        if ((index <= 1 || index <= 2 && showTypes)
             || headerInterval > 0 && index % headerInterval == 0) {
           if (index == 0) {
             printRow(header, style.getHeaderTopLeft() + hLine,
                  hLine + style.getHeaderTopRight());
+            printRow(headerCols, style.getHeaderSeparator() + " ",
+                " " + style.getHeaderSeparator());
+          } else if (index == 1 && showTypes) {
             printRow(headerCols, style.getHeaderSeparator() + " ",
                 " " + style.getHeaderSeparator());
           } else {
@@ -74,7 +79,8 @@ class TableOutputFormat implements OutputFormat {
         }
       }
 
-      if (index != 0) { // don't output the header twice
+      // don't output the header twice
+      if (!isHeader) {
         printRow(attributedString,
             style.getBodySeparator() + " ", " " + style.getBodySeparator());
       }

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -338,7 +338,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --showTime=[true/false]         display execution time when verbose\n \
 \  --showWarnings=[true/false]     display connection warnings\n \
 \  --showNestedErrs=[true/false]   display nested errors\n \
-\  --showType=[true/false]         display column types\n \
+\  --showTypes=[true/false]        display column types\n \
 \  --strictJdbc=[true/false]       use strict JDBC\n \
 \  --nullValue=[string]            use string in place of NULL values\n \
 \  --numberFormat=[pattern]        format numbers using DecimalFormat pattern\n \

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -150,6 +150,7 @@ variables:\
 \nshowHeader      true/false Show column names in query results\
 \nshowLineNumbers true/false Show line numbers while multiline queries\
 \nshowNestedErrs  true/false Display nested errors\
+\nshowTypes       true/false Display column types\
 \nshowWarnings    true/false Display connection warnings\
 \nsilent          true/false Be more silent\
 \nstrictJdbc      true/false Use strict JDBC\
@@ -337,6 +338,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --showTime=[true/false]         display execution time when verbose\n \
 \  --showWarnings=[true/false]     display connection warnings\n \
 \  --showNestedErrs=[true/false]   display nested errors\n \
+\  --showType=[true/false]         display column types\n \
 \  --strictJdbc=[true/false]       use strict JDBC\n \
 \  --nullValue=[string]            use string in place of NULL values\n \
 \  --numberFormat=[pattern]        format numbers using DecimalFormat pattern\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -141,6 +141,7 @@ rowlimit
 showheader
 shownestederrs
 showtime
+showtypes
 showwarnings
 strictJdbc
 silent
@@ -286,6 +287,7 @@ prompt
 rightprompt
 rowlimit
 showheader
+showtypes
 shownestederrs
 showtime
 showwarnings
@@ -1205,6 +1207,7 @@ showCompletionDesc true/false Display help for completions
 showElapsedTime true/false Display execution time when verbose
 showHeader      true/false Show column names in query results
 showNestedErrs  true/false Display nested errors
+showTypes       true/false Display column types
 showWarnings    true/false Display connection warnings
 silent          true/false Be more silent
 strictJdbc      true/false Use strict JDBC
@@ -2222,6 +2225,7 @@ rowlimit
 showheader
 shownestederrs
 showtime
+showtypes
 showwarnings
 silent
 strictJdbc
@@ -2364,6 +2368,10 @@ If true, display any nested errors that are reported on the connection after iss
 showtime
 
 If true, display execution time for database commands when in verbose mode. Defaults to true.
+
+showtypes
+
+If true and showheader is true, display the types of the columns when displaying results. Defaults to true.
 
 showwarnings
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -482,6 +482,29 @@ public class SqlLineArgsTest {
         containsString("| 1           | null        |     |\n"));
   }
 
+  @Test
+  public void testTableOutputWithoutTypes() {
+    final String script = "!set showTypes true\n"
+        + "!set incremental true\n"
+        + "values (1, cast(null as integer), cast(null as varchar(3)));\n";
+    checkScriptFile(script, false,
+        equalTo(SqlLine.Status.OK),
+        allOf(
+            containsString("| INTEGER | INTEGER | VARCHAR |\n"),
+            containsString("| 1           | null        |     |\n")));
+  }
+
+  @Test
+  public void testTableOutputWithoutTypesButWithoutHeader() {
+    final String script = "!set showTypes true\n"
+        + "!set showHeader false\n"
+        + "!set incremental true\n"
+        + "values (1, cast(null as integer), cast(null as varchar(3)));\n";
+    checkScriptFile(script, false,
+        equalTo(SqlLine.Status.OK),
+            containsString("| 1           | null        |     |\n"));
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 2, 3, 4})
   public void testTableOutputWithoutTerminalAndWithSmallWidth(int maxWidth) {


### PR DESCRIPTION
The PR introduces a new property `showTypes` (default: `false`) to indicate if column types should be displayed.
In case `showHeader` is `true` then types will NOT be shown as types are showing within the header.

fixes #157 