### PR TITLE
[SQLLINE-391] Set error code when -e command fails

### DIFF
--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -459,7 +459,7 @@ public class SqlLine {
 
       for (String command : commands) {
         debug(loc("executing-command", command));
-        dispatch(command, new DispatchCallback());
+        dispatch(command, callback);
       }
 
       exit = true; // execute and exit


### PR DESCRIPTION
The PR fixes #391 
now 
```
$ bin/sqlline -e '!tables'
No current connection
$ echo $?
2

```