### PR TITLE
[SQLLINE-410] Respect line separator while column size calculations

### DIFF
--- a/src/main/java/sqlline/Rows.java
+++ b/src/main/java/sqlline/Rows.java
@@ -22,6 +22,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.Format;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -217,7 +218,8 @@ abstract class Rows implements Iterator<Rows.Row> {
       sizes = new int[size];
       for (int i = 0; i < size; i++) {
         values[i] = rsMeta.getColumnLabel(i + 1);
-        sizes[i] = values[i] == null ? 1 : values[i].length();
+        sizes[i] = values[i] == null ? 1 : Arrays.stream(values[i].split("\n"))
+            .map(String::length).max(Integer::compare).orElse(1);
       }
 
       deleted = false;
@@ -288,7 +290,8 @@ abstract class Rows implements Iterator<Rows.Row> {
             : escapeOutput
                 ? escapeControlSymbols(values[i])
                 : values[i];
-        sizes[i] = values[i] == null ? 1 : values[i].length();
+        sizes[i] = values[i] == null ? 1 : Arrays.stream(values[i].split("\n"))
+            .map(String::length).max(Integer::compare).orElse(1);
       }
     }
 

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -2500,6 +2500,25 @@ public class SqlLineArgsTest {
   }
 
   @Test
+  public void testMaxColumnWidthForLongString() {
+    final String script1 = "!set maxcolumnwidth 30\n"
+        + "!set incremental true\n"
+        + "values ('This is a very long string\n"
+        + "This is a very long string\n"
+        + "This is a very long string')";
+    final String line1 = ""
+        + "+--------------------------------+\n"
+        + "|               C1               |\n"
+        + "+--------------------------------+\n"
+        + "| This is a very long string \n"
+        + "This is a very long string \n"
+        + "This is a very long  |\n"
+        + "+--------------------------------+";
+    checkScriptFile(script1, true, equalTo(SqlLine.Status.OK),
+        containsString(line1));
+  }
+
+  @Test
   public void testMaxColumnWidthIncremental() {
     final String script1 = "!set maxcolumnwidth -1\n"
             + "!set incremental true\n"


### PR DESCRIPTION
The PR takes into account line separators in string values while column size calculations
fixes #410 