### PR TITLE
[SQLLINE-254] Live templates via a separate properties file

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -3313,6 +3313,13 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           will not be removed before. Defaults to false.
         </para>
       </sect1>
+      <sect1 id="setting_liveTemplates">
+        <title>liveTemplates</title>
+        <para>
+          The file containing a list of live templates.
+          Defaults to empty.
+        </para>
+      </sect1>
       <sect1 id="setting_maxcolumnwidth">
         <title>maxcolumnwidth</title>
         <para>

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -58,6 +58,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   ISOLATION("isolation", Type.STRING, "TRANSACTION_REPEATABLE_READ",
       true, false, new HashSet<>(new Application().getIsolationLevels())),
   KEEP_SEMICOLON("keepSemicolon", Type.BOOLEAN, false),
+  LIVE_TEMPLATES("liveTemplates", Type.STRING, ""),
   MAX_COLUMN_WIDTH("maxColumnWidth", Type.INTEGER, -1),
   // don't save maxheight, maxwidth: it is automatically set based on
   // the terminal configuration

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -58,7 +58,7 @@ public enum BuiltInProperty implements SqlLineProperty {
   ISOLATION("isolation", Type.STRING, "TRANSACTION_REPEATABLE_READ",
       true, false, new HashSet<>(new Application().getIsolationLevels())),
   KEEP_SEMICOLON("keepSemicolon", Type.BOOLEAN, false),
-  LIVE_TEMPLATES("liveTemplates", Type.STRING, ""),
+  LIVE_TEMPLATES("liveTemplates", Type.FILE_PATH, ""),
   MAX_COLUMN_WIDTH("maxColumnWidth", Type.INTEGER, -1),
   // don't save maxheight, maxwidth: it is automatically set based on
   // the terminal configuration

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -643,20 +643,24 @@ public class SqlLine {
           .highlighter(new SqlLineHighlighter(this))
           .expander(new SqlLineExpander(this))
           .build();
-      autopairWidgets = new AutopairWidgets(lineReader);
-      toggleJlineAutopairWidget(getOpts().getAutoPairing());
-      addWidget(lineReader,
-          this::toggleAutopairWidget, "AUTOPAIRING", alt(ctrl('p')));
-      addWidget(lineReader,
-          this::nextColorSchemeWidget, "CHANGE_COLOR_SCHEME", alt('h'));
-      addWidget(lineReader,
-          this::toggleLineNumbersWidget, "TOGGLE_LINE_NUMBERS", alt(ctrl('n')));
+      addSqlLineWidgets(lineReader);
     } else {
       lineReader = lineReaderBuilder.build();
     }
     fileHistory.attach(lineReader);
     setLineReader(lineReader);
     return lineReader;
+  }
+
+  private void addSqlLineWidgets(LineReader lineReader) {
+    autopairWidgets = new AutopairWidgets(lineReader);
+    toggleJlineAutopairWidget(getOpts().getAutoPairing());
+    addWidget(lineReader,
+        this::toggleAutopairWidget, "AUTOPAIRING", alt(ctrl('p')));
+    addWidget(lineReader,
+        this::nextColorSchemeWidget, "CHANGE_COLOR_SCHEME", alt('h'));
+    addWidget(lineReader,
+        this::toggleLineNumbersWidget, "TOGGLE_LINE_NUMBERS", alt(ctrl('n')));
   }
 
   private void addWidget(

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -635,22 +635,25 @@ public class SqlLine {
         .option(LineReader.Option.AUTO_LIST, false)
         .option(LineReader.Option.AUTO_MENU, true)
         .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
-    final LineReader lineReader = inputStream == null
-        ? lineReaderBuilder
+    final LineReader lineReader;
+    if (inputStream == null) {
+      lineReader = lineReaderBuilder
           .appName("sqlline")
           .completer(new SqlLineCompleter(this))
           .highlighter(new SqlLineHighlighter(this))
-          .build()
-        : lineReaderBuilder.build();
-
-    autopairWidgets = new AutopairWidgets(lineReader);
-    toggleJlineAutopairWidget(getOpts().getAutoPairing());
-    addWidget(lineReader,
-        this::toggleAutopairWidget, "AUTOPAIRING", alt(ctrl('p')));
-    addWidget(lineReader,
-        this::nextColorSchemeWidget, "CHANGE_COLOR_SCHEME", alt('h'));
-    addWidget(lineReader,
-        this::toggleLineNumbersWidget, "TOGGLE_LINE_NUMBERS", alt(ctrl('n')));
+          .expander(new SqlLineExpander(this))
+          .build();
+      autopairWidgets = new AutopairWidgets(lineReader);
+      toggleJlineAutopairWidget(getOpts().getAutoPairing());
+      addWidget(lineReader,
+          this::toggleAutopairWidget, "AUTOPAIRING", alt(ctrl('p')));
+      addWidget(lineReader,
+          this::nextColorSchemeWidget, "CHANGE_COLOR_SCHEME", alt('h'));
+      addWidget(lineReader,
+          this::toggleLineNumbersWidget, "TOGGLE_LINE_NUMBERS", alt(ctrl('n')));
+    } else {
+      lineReader = lineReaderBuilder.build();
+    }
     fileHistory.attach(lineReader);
     setLineReader(lineReader);
     return lineReader;

--- a/src/main/java/sqlline/SqlLineExpander.java
+++ b/src/main/java/sqlline/SqlLineExpander.java
@@ -1,0 +1,74 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.jline.reader.Expander;
+import org.jline.reader.History;
+
+/**
+ * SQLLine expander class for live templates.
+ */
+public class SqlLineExpander implements Expander {
+  private final SqlLine sqlLine;
+  private Properties expandProperties = null;
+
+  public SqlLineExpander(SqlLine sqlLine) {
+    this.sqlLine = sqlLine;
+  }
+
+  @Override public String expandHistory(History history, String line) {
+    return line;
+  }
+
+  @Override public String expandVar(String word) {
+    if (expandProperties != null) {
+      final String expandValue = (String) expandProperties.get(word);
+      if (expandValue != null) {
+        return expandValue;
+      }
+    }
+    return word;
+  }
+
+  public void reset() {
+    expandProperties = null;
+    final String liveTemplatesFile = sqlLine.getOpts().getLiveTemplatesFile();
+    if (Objects.equals(liveTemplatesFile,
+        BuiltInProperty.LIVE_TEMPLATES.defaultValue())) {
+      return;
+    }
+    final File path = new File(liveTemplatesFile);
+    if (!path.exists() || !path.isFile()) {
+      sqlLine.error(sqlLine.loc("no-file", path.getAbsolutePath()));
+      return;
+    }
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(
+            new FileInputStream(path), StandardCharsets.UTF_8))) {
+      expandProperties = new Properties();
+      expandProperties.load(reader);
+    } catch (IOException e) {
+      sqlLine.error(e);
+    }
+  }
+}
+
+// End SqlLineExpander.java

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -36,6 +36,7 @@ table: Table
 column: Column
 new-size-after-resize: New size: height = {0}, width = {1}
 empty-value-not-supported: Empty value for type {0} not supported
+no-file: File {0} does not exist or is a directory
 
 jdbc-level: JDBC level
 compliant: Compliant
@@ -123,6 +124,7 @@ variables:\
 \n                           mode; query starts in non-incremental mode, but\
 \n                           after the this many rows, switches to incremental\
 \nisolation       LEVEL      Set transaction isolation level\
+\nliveTemplates   path       File with live templates\
 \nkeepSemicolon   true/false Keep semicolon in queries\
 \nmaxColumnWidth  integer    The maximum width to use when displaying columns\
 \nmaxHeight       integer    The maximum height of the terminal\
@@ -371,4 +373,5 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --tableStyle=[default/solid/double_solid/round_corners/bold_header]\n \
 \                                  table output style\
 \  --keepSemicolon=[true/false]    keep semicolon in queries\n \
+\  --liveTemplates=/path/to/file   file with live templates\n \
 \  --help                          display this message

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -128,6 +128,7 @@ historyfile
 incremental
 isolation
 keepSemicolon
+liveTemplates
 maxcolumnwidth
 maxHistoryFileRows
 maxHistoryRows
@@ -277,6 +278,7 @@ historyfile
 incremental
 isolation
 keepSemicolon
+liveTemplates
 maxcolumnwidth
 maxHistoryFileRows
 maxHistoryRows
@@ -1186,6 +1188,7 @@ incrementalBufferRows integer Enter incremental mode if a query returns more
                               than "incrementalBufferRows".
 isolation       LEVEL      Set transaction isolation level
 keepSemicolon   true/false Keep semicolon in queries
+liveTemplates   path       File with live templates
 maxColumnWidth  integer    The maximum width to use when displaying columns
 maxHeight       integer    The maximum height of the terminal
 maxWidth        integer    The maximum width of the terminal
@@ -2215,6 +2218,7 @@ historyfile
 incremental
 isolation
 keepSemicolon
+liveTemplates
 maxcolumnwidth
 maxHistoryFileRows
 maxHistoryRows
@@ -2310,6 +2314,10 @@ The default transaction isolation that will be used for new connections. To chan
 keepSemicolon
 
 When set to true, semicolon at the end of queries will not be removed before. Defaults to false.
+
+liveTemplates
+
+The file containing a list of live templates. Defaults to empty.
 
 maxcolumnwidth
 

--- a/src/test/java/sqlline/SqlLineExpanderTest.java
+++ b/src/test/java/sqlline/SqlLineExpanderTest.java
@@ -1,0 +1,93 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Modified BSD License
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at:
+//
+// http://opensource.org/licenses/BSD-3-Clause
+*/
+package sqlline;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Stream;
+
+import org.jline.reader.impl.LineReaderImpl;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.of;
+import static sqlline.SqlLineArgsTest.begin;
+
+/**
+ * Test cases for expander.
+ */
+public class SqlLineExpanderTest {
+  private static SqlLine sqlLine;
+
+  @BeforeAll
+  public static void setUp() throws IOException {
+    System.setProperty(TerminalBuilder.PROP_DUMB, Boolean.TRUE.toString());
+
+    sqlLine = new SqlLine();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+    File liveTemplatesFile = Files.createTempFile("expander_", "").toFile();
+    try (BufferedWriter bw =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(liveTemplatesFile),
+                StandardCharsets.UTF_8))) {
+      StringJoiner joiner = new StringJoiner("\n");
+      expansionMap().forEach((key, value) ->
+          joiner.add(key + ": " + value.replaceAll("\n", "\\\\n\\\\")));
+      final String fileContent = joiner.toString();
+      bw.write(fileContent);
+      bw.flush();
+    }
+    begin(sqlLine, os, false, "-e", "!set maxcolumnwidth 80");
+    ((LineReaderImpl) sqlLine.getLineReader())
+        .setExpander(new SqlLineExpander(sqlLine));
+    sqlLine.getOpts().setLiveTemplatesFile(liveTemplatesFile.getAbsolutePath());
+    os.reset();
+  }
+
+  private static Map<String, String> expansionMap() {
+    Map<String, String> map = new HashMap<>();
+    map.put("epf", "explain plan for ");
+    map.put("ctas", "create table as select ");
+    map.put("mepf", "explain \n plan \n for ");
+    return map;
+  }
+
+  @ParameterizedTest
+  @MethodSource("expandedValuesProvider")
+  public void testV(String liveTemplate, String expected) {
+    assertEquals(expected,
+        sqlLine.getLineReader().getExpander().expandVar(liveTemplate));
+  }
+
+  protected static Stream<Arguments> expandedValuesProvider() {
+    return Stream.of(
+        expansionMap().entrySet().stream()
+            .map(t -> of(t.getKey(), t.getValue())).toArray(Arguments[]::new)
+    );
+  }
+}
+
+// End SqlLineExpanderTest.java


### PR DESCRIPTION
The PR provides support for live templates which could be configured via a separate file in properties format.
`TAB` expands live template to the defined value. Could be useful to speed up writing similar queries.
There is also a short demo about it https://asciinema.org/a/374609?speed=3.0&t=5

Fixes #254 