### PR TITLE
[SQLLINE-415] Switch off highlighting in manual, ignore case while se…

### DIFF
--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -1914,7 +1914,7 @@ public class Commands {
       try {
         org.jline.builtins.Commands.less(sqlLine.getLineReader().getTerminal(),
             in, sqlLine.getOutputStream(), sqlLine.getErrorStream(),
-            null, new String[]{});
+            null, new String[]{"-I", "--syntax=none"});
       } catch (Exception e) {
         callback.setToFailure();
         sqlLine.error(e);


### PR DESCRIPTION
The PR turns off highlighting for `!manual` and sets ignoring case while searching through manual

fixes #415 