### PR TITLE
[SQLLINE-417] Update jline to 3.18.0. Add geshi color scheme

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
     <top.dir>${project.basedir}</top.dir>
 
     <!-- The following list is sorted. -->
-    <checkstyle.version>8.36.2</checkstyle.version>
+    <checkstyle.version>8.37</checkstyle.version>
     <docbkx-maven-plugin.version>2.0.17</docbkx-maven-plugin.version>
     <forbiddenapis.version>3.1</forbiddenapis.version>
     <h2.version>1.4.200</h2.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hsqldb.version>2.5.0</hsqldb.version>
-    <jline.version>3.16.0</jline.version>
+    <jline.version>3.18.0</jline.version>
     <jmockit.version>1.49</jmockit.version>
     <junit.version>5.7.0</junit.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>

--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -3245,9 +3245,9 @@ java.sql.SQLException: ORA-00942: table or view does not exist
         <title>colorscheme</title>
         <para>
             If <literal>chester</literal>/<literal>dark</literal>
-            /<literal>dracula</literal>/<literal>light</literal>
-            /<literal>obsidian</literal>/<literal>solarized</literal>
-            /<literal>vs2010</literal>,
+            /<literal>dracula</literal>/<literal>geshi</literal>
+            /<literal>light</literal>/<literal>obsidian</literal>
+            /<literal>solarized</literal>/<literal>vs2010</literal>,
             then this scheme will be used for command/sql syntax highlighting.
             If <literal>default</literal> then there is no syntax highlighting.
         </para>

--- a/src/main/java/sqlline/BuiltInHighlightStyle.java
+++ b/src/main/java/sqlline/BuiltInHighlightStyle.java
@@ -33,6 +33,10 @@ import static sqlline.AttributedStyles.*;
  * <a href="https://github.com/ozmoroz/ozbsidian-sqldeveloper">
  * ozmoroz's OzBsidian colour scheme for Oracle SQL Developer</a>.
  *
+ * <p>Similarly, the {@link #GESHI} style is inspired by
+ * <a href="https://github.com/GeSHi/geshi-1.0/blob/master/src/geshi/sql.php">
+ * GeSHi - Generic Syntax Highlighter for sql</a>
+ *
  * @see HighlightStyle
  */
 enum BuiltInHighlightStyle {
@@ -42,7 +46,14 @@ enum BuiltInHighlightStyle {
   DRACULA(BOLD_MAGENTA, BOLD_WHITE, GREEN, RED, ITALIC_CYAN, YELLOW, WHITE),
   SOLARIZED(BOLD_YELLOW, BOLD_BLUE, GREEN, RED, ITALIC_BRIGHT, CYAN, BLUE),
   VS2010(BOLD_BLUE, BOLD_WHITE, RED, MAGENTA, ITALIC_GREEN, BRIGHT, WHITE),
-  OBSIDIAN(BOLD_GREEN, BOLD_WHITE, RED, MAGENTA, ITALIC_BRIGHT, YELLOW, WHITE);
+  OBSIDIAN(BOLD_GREEN, BOLD_WHITE, RED, MAGENTA, ITALIC_BRIGHT, YELLOW, WHITE),
+  GESHI(AttributedStyle.BOLD.foreground(99, 33, 33),
+      BOLD_WHITE,
+      AttributedStyle.DEFAULT.foreground(0x66, 0xCC, 0x66),
+      AttributedStyle.DEFAULT.foreground(0x0, 0x0, 0x99),
+      AttributedStyle.DEFAULT.italic().foreground(0x80, 0x80, 0x80),
+      AttributedStyle.DEFAULT.foreground(0xCC, 0x66, 0xCC),
+      WHITE);
 
   final HighlightStyle style;
 

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -658,6 +658,7 @@ public class SqlLine {
         .variable(LineReader.LINE_OFFSET, 1)  // start line numbers with 1
         .option(LineReader.Option.AUTO_LIST, false)
         .option(LineReader.Option.AUTO_MENU, true)
+        .option(LineReader.Option.GROUP_PERSIST, true)
         .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
     final LineReader lineReader;
     if (inputStream == null) {

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -97,7 +97,7 @@ variables:\
 \n                           max height/width based on terminal size\
 \nautoSave        true/false Automatically save preferences\
 \ncolor           true/false Control whether color is used for display\
-\ncolorScheme     chester/dark/dracula/light/obsidian/solarized/vs2010\
+\ncolorScheme     chester/dark/dracula/geshi/light/obsidian/solarized/vs2010\
 \n                           Syntax highlight schema\
 \nconfirm         true/false Whether to prompt for confirmation before running\
 \n                           commands specified in confirmPattern (default:\
@@ -325,7 +325,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  -ac <class name>                application configuration class name\n \
 \  -ph <class name>                prompt handler class name\n \
 \  --color=[true/false]            control whether color is used for display\n \
-\  --colorScheme=[chester/dark/dracula/light/obsidian/solarized/vs2010]\
+\  --colorScheme=[chester/dark/dracula/geshi/light/obsidian/solarized/vs2010]\
 \                                  syntax highlight schema\n \
 \  --confirm=[true/false]          confirm before executing commands specified in confirmPattern\n \
 \  --confirmPattern=[pattern]      pattern of commands to prompt confirmation\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -1179,7 +1179,7 @@ Variable        Value      Description
 autoCommit      true/false Enable/disable automatic transaction commit
 autoSave        true/false Automatically save preferences
 color           true/false Control whether color is used for display
-colorScheme     chester/dark/dracula/light/obsidian/solarized/vs2010
+colorScheme     chester/dark/dracula/geshi/light/obsidian/solarized/vs2010
                            Syntax highlight schema
 confirm         true/false Prompts for confirmation before running
                            commands specified in confirmPattern
@@ -2295,7 +2295,7 @@ If true, then output to the terminal will use color for a more pleasing visual e
 
 colorScheme
 
-If chester/dark/dracula/light/obsidian/solarized/vs2010, then this scheme will be used for command/sql syntax highlighting. If default then there is no syntax highlighting.
+If chester/dark/dracula/geshi/light/obsidian/solarized/vs2010, then this scheme will be used for command/sql syntax highlighting. If default then there is no syntax highlighting.
 
 confirm
 

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -773,13 +773,13 @@ public class SqlLineHighlighterTest {
     final AttributedString attributedString =
         highlighter.highlight(sqlLine.getLineReader(), line);
     final HighlightStyle highlightStyle = sqlLine.getHighlightStyle();
-    int commandStyle = highlightStyle.getCommandStyle().getStyle();
-    int keywordStyle = highlightStyle.getKeywordStyle().getStyle();
-    int singleQuoteStyle = highlightStyle.getQuotedStyle().getStyle();
-    int identifierStyle = highlightStyle.getIdentifierStyle().getStyle();
-    int commentStyle = highlightStyle.getCommentStyle().getStyle();
-    int numberStyle = highlightStyle.getNumberStyle().getStyle();
-    int defaultStyle = highlightStyle.getDefaultStyle().getStyle();
+    long commandStyle = highlightStyle.getCommandStyle().getStyle();
+    long keywordStyle = highlightStyle.getKeywordStyle().getStyle();
+    long singleQuoteStyle = highlightStyle.getQuotedStyle().getStyle();
+    long identifierStyle = highlightStyle.getIdentifierStyle().getStyle();
+    long commentStyle = highlightStyle.getCommentStyle().getStyle();
+    long numberStyle = highlightStyle.getNumberStyle().getStyle();
+    long defaultStyle = highlightStyle.getDefaultStyle().getStyle();
 
     for (int i = 0; i < line.length(); i++) {
       checkSymbolStyle(line, i, expectedHighlightStyle.commands,
@@ -811,7 +811,7 @@ public class SqlLineHighlighterTest {
       SqlLineHighlighter defaultHighlighter) {
     final AttributedString attributedString =
         defaultHighlighter.highlight(sqlLine.getLineReader(), line);
-    int defaultStyle = AttributedStyle.DEFAULT.getStyle();
+    long defaultStyle = AttributedStyle.DEFAULT.getStyle();
 
     for (int i = 0; i < line.length(); i++) {
       if (Character.isWhitespace(line.charAt(i))) {
@@ -850,7 +850,7 @@ public class SqlLineHighlighterTest {
       int i,
       BitSet styleBitSet,
       AttributedString highlightedLine,
-      int style,
+      long style,
       String styleName) {
     if (styleBitSet.get(i)) {
       assertEquals(i == 0 ? style + 32 : style,


### PR DESCRIPTION
The PR 
1. updates jline to 3.18.0
2. enables grouping during autocompletion (feature was active by default in previous versions)
3. introduces an example of 24-bit color schema based on https://github.com/GeSHi/geshi-1.0/blob/master/src/geshi/sql.php

fixes #417 
