### PR TITLE
[SQLLINE-394] Make script engine configurable via property

### DIFF
--- a/src/docbkx/manual.xml
+++ b/src/docbkx/manual.xml
@@ -3507,6 +3507,13 @@ java.sql.SQLException: ORA-00942: table or view does not exist
           Defaults to 0, which is interpreted as fetching all rows.
         </para>
       </sect1>
+      <sect1 id="setting_scriptengine">
+        <title>scriptengine</title>
+        <para>
+          A script engine to use to evaluate scripts for
+          instance from promptScript. Defaults to nashorn.
+        </para>
+      </sect1>
       <sect1 id="setting_showcompletiondesc">
         <title>showcompletiondesc</title>
         <para>

--- a/src/main/java/sqlline/BuiltInProperty.java
+++ b/src/main/java/sqlline/BuiltInProperty.java
@@ -87,6 +87,8 @@ public enum BuiltInProperty implements SqlLineProperty {
   RIGHT_PROMPT("rightPrompt", Type.STRING, ""),
   ROW_LIMIT("rowLimit", Type.INTEGER, 0),
   SHOW_ELAPSED_TIME("showElapsedTime", Type.BOOLEAN, true),
+  SCRIPT_ENGINE("scriptEngine", Type.STRING, "nashorn", true, false,
+      new Application().getAvailableScriptEngineNames()),
   SHOW_COMPLETION_DESCR("showCompletionDesc", Type.BOOLEAN, true),
   SHOW_HEADER("showHeader", Type.BOOLEAN, true),
   SHOW_LINE_NUMBERS("showLineNumbers", Type.BOOLEAN, false),

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -1100,17 +1100,11 @@ public class SqlLineOpts implements Completer {
     }
     final ScriptEngineManager engineManager = new ScriptEngineManager();
     ScriptEngine scriptEngine = engineManager.getEngineByName(engineName);
-    if (scriptEngine == null) {
-      if (engineManager.getEngineFactories().isEmpty()) {
-        sqlLine.error(sqlLine.loc("not-supported-script-engine-no-available",
-            engineName));
-      } else {
-        sqlLine.error(sqlLine.loc("not-supported-script-engine",
-            engineName, SCRIPT_ENGINE.getAvailableValues()));
-      }
-    } else {
-      set(SCRIPT_ENGINE, engineName);
+    if (scriptEngine == null && engineManager.getEngineFactories().isEmpty()) {
+      sqlLine.error(sqlLine.loc("not-supported-script-engine-no-available",
+          engineName));
     }
+    set(SCRIPT_ENGINE, engineName);
   }
 }
 

--- a/src/main/resources/sqlline/SqlLine.properties
+++ b/src/main/resources/sqlline/SqlLine.properties
@@ -37,6 +37,8 @@ column: Column
 new-size-after-resize: New size: height = {0}, width = {1}
 empty-value-not-supported: Empty value for type {0} not supported
 no-file: File {0} does not exist or is a directory
+not-supported-script-engine: Not found script engine "{0}", available values: {1}
+not-supported-script-engine-no-available: Not found script engine "{0}", no available script engines
 
 jdbc-level: JDBC level
 compliant: Compliant
@@ -151,6 +153,7 @@ variables:\
 \nrightPrompt     pattern    Format right prompt\
 \nrowLimit        integer    Maximum number of rows returned from a query; zero\
 \n                           means no limit\
+\nscriptEngine    String     Script engine name\
 \nshowCompletionDesc true/false Display help for completions\
 \nshowElapsedTime true/false Display execution time when verbose\
 \nshowHeader      true/false Show column names in query results\
@@ -340,6 +343,7 @@ cmd-usage: Usage: java sqlline.SqlLine \n \
 \  --autoCommit=[true/false]       enable/disable automatic transaction commit\n \
 \  --readOnly=[true/false]         enable/disable readonly connection\n \
 \  --verbose=[true/false]          show verbose error messages and debug info\n \
+\  --scriptEngine=[string]         script engine name\n \
 \  --showCompletionDesc=[true/false] display help for completions\n \
 \  --showLineNumbers=[true/false]  show line numbers while multiline queries\n \
 \  --showTime=[true/false]         display execution time when verbose\n \

--- a/src/main/resources/sqlline/manual.txt
+++ b/src/main/resources/sqlline/manual.txt
@@ -104,6 +104,8 @@ schemas
 schemas — List all the schemas in the database
 script
 script — Save executed commands to a file
+scriptengine
+scriptengine - script engine name
 set
 set — Set a preference
 showconfconnections
@@ -258,6 +260,8 @@ scan
 scan — Scan class path for JDBC drivers
 script
 script — Save executed commands to a file
+scriptengine
+scriptengine - script engine name
 set
 set — Set a preference
 showconfconnections
@@ -502,6 +506,8 @@ scan
 scan — Scan class path for JDBC drivers
 script
 script — Save executed commands to a file
+scriptengine
+scriptengine - script engine name
 set
 set — Set a preference
 showconfconnections
@@ -1223,6 +1229,7 @@ propertiesFile  path       File from which SQLLine reads properties on
 rightPrompt     pattern    Format right prompt
 rowLimit        integer    Maximum number of rows returned from a query; zero
                            means no limit
+scriptEngine    string     Script engine name
 showCompletionDesc true/false Display help for completions
 showElapsedTime true/false Display execution time when verbose
 showHeader      true/false Show column names in query results
@@ -2410,6 +2417,10 @@ hsql database engine:0>
 rowlimit
 
 The maximum number of rows to fetch per query. Defaults to 0, which is interpreted as fetching all rows.
+
+scriptengine
+
+A script engine to use to evaluate scripts for instance from promptScript. Defaults to nashorn.
 
 showheader
 

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import javax.script.ScriptEngineManager;
 
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
@@ -221,8 +222,9 @@ public class PromptTest {
    * The `promptscript` property is broken on JDK 15 and higher</a>. */
   @Test
   public void testPromptScript() {
-    Assumptions.assumeTrue(getJavaMajorVersion() < 15,
-        "promptscript fails on JDK 15 and higher; "
+    Assumptions.assumeTrue(
+        !new ScriptEngineManager().getEngineFactories().isEmpty(),
+        "promptscript fails if there is no script engines; "
             + "see ");
 
     sqlLine.getOpts().set(BuiltInProperty.PROMPT_SCRIPT, "'hel' + 'lo'");


### PR DESCRIPTION
The PR introduces a new property `scriptEngine` to specify which script engine to use (from those which are available via spi).

Each script engine could have plenty of names and these names could be intersected across multiple script engines. To cope with it sqlline uses for autocompletion only those which are not referring to multiple engines and to reduce multiple names it uses only one name per engine.

a short demo of how it works https://asciinema.org/a/382251?speed=3.0 

will allow to switch to a different script engine for java15+ and cope with #394  