### PR TITLE
Fix default prompt when there is no database connection.

### DIFF
--- a/src/main/java/sqlline/PromptHandler.java
+++ b/src/main/java/sqlline/PromptHandler.java
@@ -110,8 +110,9 @@ public class PromptHandler {
     final boolean useDefaultPrompt =
         sqlLine.getOpts().isDefault(BuiltInProperty.PROMPT);
     if (dbc == null || dbc.getUrl() == null) {
-      return getPrompt(sqlLine, connectionIndex,
-          useDefaultPrompt ? defaultPrompt : currentPrompt);
+      return getPrompt(sqlLine, connectionIndex, useDefaultPrompt
+          ? getDefaultPrompt(connectionIndex, null, defaultPrompt)
+          : currentPrompt);
     } else {
       if (useDefaultPrompt || dbc.getNickname() != null) {
         final String nickNameOrUrl =

--- a/src/test/java/sqlline/PromptTest.java
+++ b/src/test/java/sqlline/PromptTest.java
@@ -248,6 +248,11 @@ public class PromptTest {
   @Test
   public void testCustomPromptHandler() {
     sqlLine.runCommands(new DispatchCallback(),
+        "!prompthandler sqlline.extensions.CustomPromptHandler");
+    assertThat(sqlLine.getPromptHandler().getPrompt().toAnsi(),
+        is("my_app>"));
+
+    sqlLine.runCommands(new DispatchCallback(),
         "!connect "
             + SqlLineArgsTest.ConnectionSpec.H2.url + " "
             + SqlLineArgsTest.ConnectionSpec.H2.username + " \"\"",


### PR DESCRIPTION
Custom `PromptHandler#getDefaultPrompt` may not work when there is no database connection.