### PR TITLE
[SQLLINE-444] Update JLine to 3.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,26 +25,26 @@
     <top.dir>${project.basedir}</top.dir>
 
     <!-- The following list is sorted. -->
-    <checkstyle.version>8.37</checkstyle.version>
+    <checkstyle.version>9.0.1</checkstyle.version>
     <docbkx-maven-plugin.version>2.0.17</docbkx-maven-plugin.version>
-    <forbiddenapis.version>3.1</forbiddenapis.version>
+    <forbiddenapis.version>3.2</forbiddenapis.version>
     <h2.version>1.4.200</h2.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hsqldb.version>2.5.0</hsqldb.version>
-    <jline.version>3.18.0</jline.version>
+    <jline.version>3.21.0</jline.version>
     <jmockit.version>1.49</jmockit.version>
-    <junit.version>5.7.0</junit.version>
+    <junit.version>5.8.1</junit.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
     <maven-javadoc-plugin.additionalOptions>-html5</maven-javadoc-plugin.additionalOptions>
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-    <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
+    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <scott-data-hsqldb.version>0.1</scott-data-hsqldb.version>

--- a/src/main/java/sqlline/Commands.java
+++ b/src/main/java/sqlline/Commands.java
@@ -275,7 +275,7 @@ public class Commands {
     String[] cmd = sqlLine.split(line);
     History history = sqlLine.getLineReader().getHistory();
     int size = history.size();
-    if (cmd.length > 2 || (cmd.length == 2 && !cmd[1].matches("-?\\d+"))) {
+    if (cmd.length > 2 || cmd.length == 2 && !cmd[1].matches("-?\\d+")) {
       if (size == 0) {
         sqlLine.error("Usage: rerun <offset>, history should not be empty");
       } else {
@@ -318,7 +318,7 @@ public class Commands {
     String command = iterator.next().line();
     if (command.trim().startsWith("!/") || command.startsWith("!rerun")) {
       String[] cmd = sqlLine.split(command);
-      if (cmd.length > 2 || (cmd.length == 2 && !cmd[1].matches("-?\\d+"))) {
+      if (cmd.length > 2 || cmd.length == 2 && !cmd[1].matches("-?\\d+")) {
         return command;
       }
       int offset = cmd.length == 1 ? -1 : Integer.parseInt(cmd[1]);

--- a/src/main/java/sqlline/JsonOutputFormat.java
+++ b/src/main/java/sqlline/JsonOutputFormat.java
@@ -35,13 +35,13 @@ public class JsonOutputFormat extends AbstractOutputFormat {
     String[] head = header.values;
     String[] vals = row.values;
     StringBuilder sb = new StringBuilder("{");
-    for (int i = 0; (i < head.length) && (i < vals.length); i++) {
+    for (int i = 0; i < head.length && i < vals.length; i++) {
       if (columnTypes == null) {
         initColumnTypes(rows, header);
       }
       sb.append("\"").append(head[i]).append("\":");
       setJsonValue(sb, vals[i], columnTypes[i]);
-      sb.append((i < head.length - 1) && (i < vals.length - 1) ? "," : "");
+      sb.append(i < head.length - 1 && i < vals.length - 1 ? "," : "");
     }
     sb.append(rows.hasNext() ? "}," : "}");
     sqlLine.output(sb.toString());

--- a/src/main/java/sqlline/PromptHandler.java
+++ b/src/main/java/sqlline/PromptHandler.java
@@ -214,9 +214,9 @@ public class PromptHandler {
               int nextColonIndex = prompt.indexOf(":", i + 2);
               SqlLineProperty property;
               if (nextColonIndex > 0
-                  && ((property = BuiltInProperty.valueOf(
+                  && (property = BuiltInProperty.valueOf(
                   prompt.substring(i + 2, nextColonIndex),
-                  true)) != null)) {
+                  true)) != null) {
                 promptStringBuilder.append(opts.get(property));
                 i = nextColonIndex - 1;
                 break;

--- a/src/main/java/sqlline/SqlCompleter.java
+++ b/src/main/java/sqlline/SqlCompleter.java
@@ -140,9 +140,9 @@ class SqlCompleter extends StringsCompleter {
     final char openQuote = sqlLine.getDialect().getOpenQuote();
     if (argumentList.getState()
         == SqlLineParser.SqlParserState.MULTILINE_COMMENT
-        || (argumentList.getState() == SqlLineParser.SqlParserState.QUOTED
-        && ((openQuote == '"' && !supplierMsg.endsWith("dquote"))
-        || (openQuote == '`' && !supplierMsg.endsWith("`"))))) {
+        || argumentList.getState() == SqlLineParser.SqlParserState.QUOTED
+        && (openQuote == '"' && !supplierMsg.endsWith("dquote")
+        || openQuote == '`' && !supplierMsg.endsWith("`"))) {
       return;
     }
 
@@ -154,10 +154,10 @@ class SqlCompleter extends StringsCompleter {
     // suggest other candidates if not quoted
     // and previous word not finished with '.'
     if (argumentList.getState() != SqlLineParser.SqlParserState.QUOTED
-        && ((argumentList.getState()
+        && (argumentList.getState()
             != SqlLineParser.SqlParserState.SEMICOLON_REQUIRED
                 && argumentList.getState()
-                   != SqlLineParser.SqlParserState.ROUND_BRACKET_BALANCE_FAILED)
+                   != SqlLineParser.SqlParserState.ROUND_BRACKET_BALANCE_FAILED
             || sql.isEmpty()
             || sql.charAt(sql.length() - 1) != '.')) {
       candidates.addAll(this.candidates);

--- a/src/main/java/sqlline/SqlLine.java
+++ b/src/main/java/sqlline/SqlLine.java
@@ -1304,17 +1304,17 @@ public class SqlLine {
       return str;
     }
 
-    if ((str.length() == 1 && (str.charAt(0) == '\'' || str.charAt(0) == '\"'))
-        || ((str.charAt(0) == '"' || str.charAt(0) == '\''
+    if (str.length() == 1 && (str.charAt(0) == '\'' || str.charAt(0) == '\"')
+        || (str.charAt(0) == '"' || str.charAt(0) == '\''
             || str.charAt(str.length() - 1) == '"'
             || str.charAt(str.length() - 1) == '\'')
-            && str.charAt(0) != str.charAt(str.length() - 1))) {
+            && str.charAt(0) != str.charAt(str.length() - 1)) {
       throw new IllegalArgumentException(
           "A quote should be closed for <" + str + ">");
     }
     char prevQuote = 0;
     int index = 0;
-    while ((str.charAt(index) == str.charAt(str.length() - index - 1))
+    while (str.charAt(index) == str.charAt(str.length() - index - 1)
         && (str.charAt(index) == '"' || str.charAt(index) == '\'')) {
       // if start and end point to the same element
       if (index == str.length() - index - 1) {
@@ -1372,10 +1372,10 @@ public class SqlLine {
         if (inQuotes) {
           i += delim.length() - 1;
           continue;
-        } else if (i > 0 && (
-            !line.regionMatches(i - delim.length(), delim, 0, delim.length())
+        } else if (i > 0
+            && !line.regionMatches(i - delim.length(), delim, 0, delim.length())
             && line.charAt(i - 1) != '\''
-            && line.charAt(i - 1) != '"')) {
+            && line.charAt(i - 1) != '"') {
           tokens.add(line.substring(tokenStart, i));
           lastProcessedIndex = i;
           i += delim.length() - 1;
@@ -1389,9 +1389,9 @@ public class SqlLine {
         tokenStart = i;
       }
     }
-    if ((lastProcessedIndex != line.length() - 1
-            && (limit == 0 || limit > tokens.size()))
-        || (lastProcessedIndex == 0 && line.length() == 1)) {
+    if (lastProcessedIndex != line.length() - 1
+            && (limit == 0 || limit > tokens.size())
+        || lastProcessedIndex == 0 && line.length() == 1) {
       tokens.add(line.substring(tokenStart));
     }
     String[] ret = new String[tokens.size()];
@@ -1503,7 +1503,7 @@ public class SqlLine {
       case '>':
         // could be skipped for xml attribute and there is no sequence ]]>
         // could be skipped for element text and there is no sequence ]]>
-        if ((i > 1 && str.charAt(i - 1) == ']' && str.charAt(i - 2) == ']')
+        if (i > 1 && str.charAt(i - 1) == ']' && str.charAt(i - 2) == ']'
             || charsCouldBeNotEncoded.indexOf(ch) == -1) {
           sb.append("&gt;");
         } else {
@@ -1749,7 +1749,7 @@ public class SqlLine {
     if ("csv".equals(format)) {
       final SeparatedValuesOutputFormat csvOutput =
           (SeparatedValuesOutputFormat) f;
-      if ((csvOutput.separator == null && getOpts().getCsvDelimiter() != null)
+      if (csvOutput.separator == null && getOpts().getCsvDelimiter() != null
           || (csvOutput.separator != null
               && !csvOutput.separator.equals(getOpts().getCsvDelimiter())
               || csvOutput.quoteCharacter

--- a/src/main/java/sqlline/SqlLineHighlighter.java
+++ b/src/main/java/sqlline/SqlLineHighlighter.java
@@ -131,10 +131,10 @@ public class SqlLineHighlighter extends DefaultHighlighter {
           sb.style(highlightStyle.getDefaultStyle());
         } else {
           final boolean defaultStyleStart =
-              (i == 0 && commandEnd == -1 && commandStart == -1)
-                  || (i > Math.max(commandEnd, commandStart)
+              i == 0 && commandEnd == -1 && commandStart == -1
+                  || i > Math.max(commandEnd, commandStart)
                       && (i < underlineStart || i > underlineEnd)
-                      && (i < negativeStart || i > negativeEnd));
+                      && (i < negativeStart || i > negativeEnd);
           if (isSql) {
             if (keywordBitSet.get(i)) {
               sb.style(highlightStyle.getKeywordStyle());
@@ -242,14 +242,14 @@ public class SqlLineHighlighter extends DefaultHighlighter {
       char ch = buffer.charAt(pos);
       if (wordStart > -1) {
         if (pos == buffer.length() - 1
-            || (!Character.isLetterOrDigit(ch) && ch != '_')) {
+            || !Character.isLetterOrDigit(ch) && ch != '_') {
           String word4codeBlock = buffer.substring(wordStart, pos + 1).trim();
           final Dialect.CodeBlocks codeBlocks = dialect.getCodeBlocks();
           if (codeBlocks != null) {
             final Predicate<String> bStarting = codeBlocks.isBlockStarting();
             final Predicate<String> bStarted = codeBlocks.isBlockStarted();
             if (bStarting != null && bStarting.test(word4codeBlock)
-                || (bStarted != null && bStarted.test(word4codeBlock))) {
+                || bStarted != null && bStarted.test(word4codeBlock)) {
               keywordBitSet.set(wordStart,
                   wordStart + word4codeBlock.length());
               wordStart = -1;
@@ -292,9 +292,9 @@ public class SqlLineHighlighter extends DefaultHighlighter {
       if (wordStart == -1
           && (Character.isDigit(ch) || ch == '.' || ch == 'e' || ch == 'E')
           && (pos == 0
-              || (buffer.length() > pos - 1
+              || buffer.length() > pos - 1
                   && !Character.isLetterOrDigit(buffer.charAt(pos - 1))
-                  && buffer.charAt(pos - 1) != '_'))) {
+                  && buffer.charAt(pos - 1) != '_')) {
         pos = handleNumbers(buffer, numberBitSet, pos);
         continue;
       }

--- a/src/main/java/sqlline/SqlLineOpts.java
+++ b/src/main/java/sqlline/SqlLineOpts.java
@@ -1011,8 +1011,8 @@ public class SqlLineOpts implements Completer {
   public void setPropertiesFile(String propertyFile) {
     final String oldPropertyFile = get(PROPERTIES_FILE);
     if (Objects.equals(propertyFile, oldPropertyFile)
-        || (Objects.equals(PROPERTIES_FILE.defaultValue(), oldPropertyFile)
-            && DEFAULT.equalsIgnoreCase(propertyFile))) {
+        || Objects.equals(PROPERTIES_FILE.defaultValue(), oldPropertyFile)
+            && DEFAULT.equalsIgnoreCase(propertyFile)) {
       return;
     }
     // reset properties

--- a/src/main/java/sqlline/SqlLineParser.java
+++ b/src/main/java/sqlline/SqlLineParser.java
@@ -210,8 +210,8 @@ public class SqlLineParser extends DefaultParser {
         if (quoteStart >= 0) {
           // In a quote block
           if ((line.charAt(quoteStart) == currentChar
-              || (currentChar == dialect.getCloseQuote()
-                  && line.charAt(quoteStart) == dialect.getOpenQuote()))
+              || currentChar == dialect.getCloseQuote()
+                  && line.charAt(quoteStart) == dialect.getOpenQuote())
               && !isEscaped(line, i)) {
             // End the block; arg could be empty, but that's fine
             if (line.charAt(quoteStart) == dialect.getOpenQuote()) {

--- a/src/main/java/sqlline/VerticalOutputFormat.java
+++ b/src/main/java/sqlline/VerticalOutputFormat.java
@@ -42,13 +42,13 @@ class VerticalOutputFormat implements OutputFormat {
     String[] head = header.values;
     String[] vals = row.values;
     int headWidth = 0;
-    for (int i = 0; (i < head.length) && (i < vals.length); i++) {
+    for (int i = 0; i < head.length && i < vals.length; i++) {
       headWidth = Math.max(headWidth, head[i].length());
     }
 
     headWidth += 2;
 
-    for (int i = 0; (i < head.length) && (i < vals.length); i++) {
+    for (int i = 0; i < head.length && i < vals.length; i++) {
       sqlLine.output(
           new AttributedStringBuilder()
               .append(rpad(head[i], headWidth), AttributedStyle.BOLD)

--- a/src/main/java/sqlline/XmlAttributeOutputFormat.java
+++ b/src/main/java/sqlline/XmlAttributeOutputFormat.java
@@ -37,7 +37,7 @@ class XmlAttributeOutputFormat extends AbstractOutputFormat {
 
     StringBuilder result = new StringBuilder("  <result");
 
-    for (int i = 0; (i < head.length) && (i < vals.length); i++) {
+    for (int i = 0; i < head.length && i < vals.length; i++) {
       result.append(' ').append(head[i]).append("=\"").append(
           SqlLine.xmlEncode(vals[i], ALLOWED_NOT_ENCODE_SYMBOLS)).append('"');
     }

--- a/src/main/java/sqlline/XmlElementOutputFormat.java
+++ b/src/main/java/sqlline/XmlElementOutputFormat.java
@@ -34,7 +34,7 @@ class XmlElementOutputFormat extends AbstractOutputFormat {
     String[] vals = row.values;
 
     sqlLine.output("  <result>");
-    for (int i = 0; (i < head.length) && (i < vals.length); i++) {
+    for (int i = 0; i < head.length && i < vals.length; i++) {
       sqlLine.output(
           "    <" + head[i] + ">"
               + (SqlLine.xmlEncode(vals[i], ALLOWED_NOT_ENCODE_SYMBOLS))


### PR DESCRIPTION
The PR updates JLine to 3.21.0
and does other updates:
checkstyle to 9.0.1 (+ removal unnecessary brackets as new checkstyle started to complain about that)
forbiddenapis to 3.2
junit to 5.8.1
maven-checkstyle-plugin to 3.1.2
maven-dependency-plugin to 3.2.0
maven-enforcer-plugin to 3.0.0
maven-javadoc-plugin to 3.3.1
maven-project-info-reports-plugin to 3.1.2
maven-gpg-plugin to 3.0.1

fixes #444 