### PR TITLE
Update h2 to 2.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <checkstyle.version>9.0.1</checkstyle.version>
     <docbkx-maven-plugin.version>2.0.17</docbkx-maven-plugin.version>
     <forbiddenapis.version>3.2</forbiddenapis.version>
-    <h2.version>2.0.206</h2.version>
+    <h2.version>2.1.210</h2.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hsqldb.version>2.5.0</hsqldb.version>
     <jline.version>3.21.0</jline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <checkstyle.version>9.0.1</checkstyle.version>
     <docbkx-maven-plugin.version>2.0.17</docbkx-maven-plugin.version>
     <forbiddenapis.version>3.2</forbiddenapis.version>
-    <h2.version>1.4.200</h2.version>
+    <h2.version>2.0.206</h2.version>
     <hamcrest.version>2.2</hamcrest.version>
     <hsqldb.version>2.5.0</hsqldb.version>
     <jline.version>3.21.0</jline.version>

--- a/src/test/java/sqlline/BufferedRowsTest.java
+++ b/src/test/java/sqlline/BufferedRowsTest.java
@@ -19,7 +19,10 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+import org.h2.result.DefaultRow;
 import org.h2.tools.SimpleResultSet;
+import org.h2.value.Value;
+import org.h2.value.ValueInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -39,7 +42,9 @@ public class BufferedRowsTest {
     try {
       SimpleResultSet rs = new SimpleResultSet();
       for (int i = 0; i < size; i++) {
-        rs.addRow(1, 2);
+        rs.addRow(
+            new DefaultRow(
+                new Value[] {ValueInteger.get(1), ValueInteger.get(2)}, 123));
       }
 
       SqlLine sqlLine = getSqlLine();

--- a/src/test/java/sqlline/BufferedRowsTest.java
+++ b/src/test/java/sqlline/BufferedRowsTest.java
@@ -19,10 +19,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.h2.result.RowImpl;
 import org.h2.tools.SimpleResultSet;
-import org.h2.value.Value;
-import org.h2.value.ValueInt;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -42,8 +39,7 @@ public class BufferedRowsTest {
     try {
       SimpleResultSet rs = new SimpleResultSet();
       for (int i = 0; i < size; i++) {
-        rs.addRow(
-            new RowImpl(new Value[] {ValueInt.get(1), ValueInt.get(2)}, 123));
+        rs.addRow(1, 2);
       }
 
       SqlLine sqlLine = getSqlLine();

--- a/src/test/java/sqlline/SqlLineArgsTest.java
+++ b/src/test/java/sqlline/SqlLineArgsTest.java
@@ -370,6 +370,7 @@ public class SqlLineArgsTest {
         final String script = "\n"
             + "\n"
             + "!set incremental true\n"
+            + "!set maxColumnWidth 10\n"
             + "\n"
             + "\n"
             + "select * from information_schema.tables// ';\n"
@@ -388,8 +389,8 @@ public class SqlLineArgsTest {
               "--run=" + tmpHistoryFile.getAbsolutePath());
       assertThat(status, equalTo(SqlLine.Status.OK));
       String output = os.toString("UTF8");
-      final String expected = "| TABLE_CATALOG | TABLE_SCHEMA |"
-          + " TABLE_NAME | TABLE_TYPE | STORAGE_TYPE | SQL  |";
+      final String expected = "| UNNAMED    |"
+          + " INFORMATION_SCHEMA | ENUM_VALUES | BASE TABLE";
       assertThat(output, containsString(expected));
       sqlLine.runCommands(new DispatchCallback(), "!quit");
       assertTrue(sqlLine.isExit());
@@ -1593,14 +1594,15 @@ public class SqlLineArgsTest {
       DispatchCallback dc = new DispatchCallback();
       sqlLine.runCommands(dc,
           "!set maxwidth 80",
+          "!set maxColumnWidth 10",
           "!set incremental true");
       sqlLine.runCommands(dc, "!connect "
           + ConnectionSpec.H2.url + " "
           + ConnectionSpec.H2.username);
       sqlLine.runCommands(dc, "!tables");
       String output = os.toString("UTF8");
-      final String expected = "| TABLE_CAT | TABLE_SCHEM | "
-          + "TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |";
+      final String expected = "| TABLE_CAT  | TABLE_SCHEM |"
+          + " TABLE_NAME | TABLE_TYPE |  REMARKS   |  TYPE_CAT  |";
       assertThat(output, containsString(expected));
       sqlLine.runCommands(new DispatchCallback(), "!quit");
       assertTrue(sqlLine.isExit());
@@ -1627,6 +1629,7 @@ public class SqlLineArgsTest {
       DispatchCallback dc = new DispatchCallback();
       sqlLine.runCommands(dc,
           "!set maxwidth 80",
+          "!set maxColumnWidth 10\n",
           "!set incremental true");
       String fakeNonEmptyPassword = "nonEmptyPasswd";
       final byte[] bytes =
@@ -1638,8 +1641,8 @@ public class SqlLineArgsTest {
           + StringUtils.convertBytesToHex(bytes));
       sqlLine.runCommands(dc, "!tables");
       String output = os.toString("UTF8");
-      final String expected = "| TABLE_CAT | TABLE_SCHEM | "
-          + "TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |";
+      final String expected = "| TABLE_CAT  | TABLE_SCHEM |"
+          + " TABLE_NAME | TABLE_TYPE |  REMARKS   |  TYPE_CAT  |";
       assertThat(output, containsString(expected));
       sqlLine.runCommands(new DispatchCallback(), "!quit");
       assertTrue(sqlLine.isExit());
@@ -1703,7 +1706,7 @@ public class SqlLineArgsTest {
     DispatchCallback dc = new DispatchCallback();
 
     try {
-      sqlLine.runCommands(dc, "!set maxwidth 80");
+      sqlLine.runCommands(dc, "!set maxwidth 80", "!set maxColumnWidth 10");
 
       // fail attempt
       String fakeNonEmptyPassword = "nonEmptyPasswd";
@@ -1729,8 +1732,8 @@ public class SqlLineArgsTest {
       sqlLine.runCommands(dc, "!set incremental true");
       sqlLine.runCommands(dc, "!tables");
       output = os.toString("UTF8");
-      final String expected1 = "| TABLE_CAT | TABLE_SCHEM | "
-          + "TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |";
+      final String expected1 = "| TABLE_CAT  | TABLE_SCHEM |"
+          + " TABLE_NAME | TABLE_TYPE |  REMARKS   |  TYPE_CAT  |";
       assertThat(output, containsString(expected1));
 
       sqlLine.runCommands(dc, "select 5;");
@@ -1864,10 +1867,11 @@ public class SqlLineArgsTest {
     // Set width so we don't inherit from the current terminal.
     final String script = "!set maxwidth 80\n"
         + "!set incremental true\n"
+        + "!set maxColumnWidth 10\n"
         + "!tables\n";
-    final String line0 = "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME |";
+    final String line0 = "| TABLE_CAT  | TABLE_SCHEM | TABLE_NAME |";
     final String line1 =
-        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE";
+        "| UNNAMED    | INFORMATION_SCHEMA | CONSTANTS  | BASE TABLE";
     checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
         allOf(containsString(line0), containsString(line1)));
   }
@@ -1878,11 +1882,12 @@ public class SqlLineArgsTest {
     // Set width so we don't inherit from the current terminal.
     final String script = "!set maxwidth 80\n"
         + "!set incremental true\n"
-        + "!tables CATALO%\n";
+        + "!set maxColumnWidth 10\n"
+        + "!tables INDEXES%\n";
     final String line0 =
-        "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |\n";
+        "| TABLE_CAT  | TABLE_SCHEM | TABLE_NAME | TABLE_TYPE |  REMARKS   |  TYPE_CAT  |\n";
     final String line1 =
-        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE |         |       |\n";
+        "| UNNAMED    | INFORMATION_SCHEMA | INDEXES    | BASE TABLE |            |     |\n";
     checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
         allOf(containsString(line0), containsString(line1)));
   }
@@ -1893,11 +1898,12 @@ public class SqlLineArgsTest {
     // Set width so we don't inherit from the current terminal.
     final String script = "!set maxwidth 80\n"
         + "!set incremental true\n"
-        + "!tables INFORMATION_% CAT% \"SYSTEM TABLE\"\n";
+        + "!set maxColumnWidth 10\n"
+        + "!tables INFORMATION_% \n";
     final String line0 =
-        "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME | TABLE_TYPE | REMARKS | TYPE_CAT | TYP |\n";
+        "| TABLE_CAT  | TABLE_SCHEM | TABLE_NAME | TABLE_TYPE |  REMARKS   |  TYPE_CAT  |\n";
     final String line1 =
-        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE |         |       |\n";
+        "| UNNAMED    | INFORMATION_SCHEMA | INFORMATION_SCHEMA_CATALOG_NAME | BASE TAB |\n";
     checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
         allOf(containsString(line0), containsString(line1)));
   }
@@ -1907,12 +1913,13 @@ public class SqlLineArgsTest {
     connectionSpec = ConnectionSpec.H2;
     // Set width so we don't inherit from the current terminal.
     final String script = "!set maxwidth 80\n"
+        + "!set maxColumnWidth 10\n"
         + "!set incremental true\n"
-        + "!columns INFORMATION% CAT% CAT%\n";
+        + "!columns INFORMATION_SCHEMA % %\n";
     final String line0 =
-        "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME | COLUMN_NAME |  DATA_TYPE  | TYPE_NAME |\n";
+        "| TABLE_CAT  | TABLE_SCHEM | TABLE_NAME | COLUMN_NAME | DATA_TYPE  | TYPE_NAME |\n";
     final String line1 =
-        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | CATALOG_NAME | 12          | V |\n";
+        "| UNNAMED    | INFORMATION_SCHEMA | CHECK_CONSTRAINTS | CONSTRAINT_CATALOG | 1 |\n";
     checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
         allOf(containsString(line0), containsString(line1)));
   }
@@ -1942,10 +1949,11 @@ public class SqlLineArgsTest {
     // Set width so we don't inherit from the current terminal.
     final String script = "!set maxwidth 80\n"
         + "!set incremental true\n"
+        + "!set maxColumnWidth 10\n"
         + "!tables\n";
-    final String line0 = "| TABLE_CAT | TABLE_SCHEM | TABLE_NAME |";
+    final String line0 = "| TABLE_CAT  | TABLE_SCHEM | TABLE_NAME |";
     final String line1 =
-        "| UNNAMED   | INFORMATION_SCHEMA | CATALOGS   | SYSTEM TABLE";
+        "| UNNAMED    | INFORMATION_SCHEMA | CONSTANTS  | BASE TABLE";
     final String message = "Could not find driver "
         + connectionSpec.driver
         + "; using registered driver org.h2.Driver instead";
@@ -2338,7 +2346,7 @@ public class SqlLineArgsTest {
         + " sqlline.extensions.CustomApplication\n"
         + "!scan";
     checkScriptFile(script, true, equalTo(SqlLine.Status.OK),
-        allOf(containsString("yes       1.4     org.h2.Driver"),
+        allOf(containsString("yes       2.1     org.h2.Driver"),
                 not(containsString("org.hsqldb.jdbc.JDBCDriver"))));
   }
 

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -553,7 +553,6 @@ public class SqlLineHighlighterTest {
         "GROUPS",
         "IF",
         "ILIKE",
-        "INTERSECTS",
         "LIMIT",
         "MINUS",
         "OFFSET",

--- a/src/test/java/sqlline/SqlLineHighlighterTest.java
+++ b/src/test/java/sqlline/SqlLineHighlighterTest.java
@@ -545,16 +545,22 @@ public class SqlLineHighlighterTest {
    */
   @Test
   public void testH2SqlKeywordsFromDatabase() {
-    // The list is taken from H2 1.4.197 getSQLKeywords output
+    // The list is taken from H2 2.0.206 getSQLKeywords output
+    // ("!metadata getSQLKeywords"). "KEY" and "_ROWID_" are also keywords.
     String[] linesRequiredToBeConnectionSpecificKeyWords = {
+        "CURRENT_CATALOG",
+        "CURRENT_SCHEMA",
+        "GROUPS",
+        "IF",
+        "ILIKE",
+        "INTERSECTS",
         "LIMIT",
         "MINUS",
         "OFFSET",
+        "QUALIFY",
+        "REGEXP",
         "ROWNUM",
-        "SYSDATE",
-        "SYSTIME",
-        "SYSTIMESTAMP",
-        "TODAY",
+        "TOP",
     };
 
     for (String line : linesRequiredToBeConnectionSpecificKeyWords) {


### PR DESCRIPTION
There are lots of changes in h2
* keywords
* default column length 
* renaming of some classes e.g. `ValueInt`, `RowImpl`
* content of `information_schema`